### PR TITLE
IR Generator support for TRON

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3251,14 +3251,14 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 			else if (auto const* addressType = dynamic_cast<AddressType const*>(exprType))
 			{
 				// Trigger error when using send or transfer with a non-payable fallback function.
-				if (memberName == "send" || memberName == "transfer")
+				if (memberName == "send" || memberName == "transfer" || memberName == "transferToken")
 				{
 					solAssert(
 						addressType->stateMutability() != StateMutability::Payable,
 						"Expected address not-payable as members were not found"
 					);
 
-					return { 9862_error, "\"send\" and \"transfer\" are only available for objects of type \"address payable\", not \"" + exprType->humanReadableName() + "\"." };
+					return { 9862_error, "\"send\", \"transfer\" and \"transferToken\" are only available for objects of type \"address payable\", not \"" + exprType->humanReadableName() + "\"." };
 				}
 			}
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3438,6 +3438,8 @@ std::vector<std::tuple<std::string, Type const*>> FunctionType::makeStackItems()
 	case Kind::Freeze:
 	case Kind::Unfreeze:
 	case Kind::FreezeExpireTime:
+	case Kind::DelegateResource:
+	case Kind::UnDelegateResource:
 		slots = {std::make_tuple("address", TypeProvider::address())};
 		break;
 	case Kind::Internal:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -647,7 +647,7 @@ MemberList::MemberMap AddressType::nativeMembers(ASTNode const*) const
 	{
 		members.emplace_back(MemberList::Member{"send", TypeProvider::function(strings{"uint"}, strings{"bool"}, FunctionType::Kind::Send, StateMutability::NonPayable)});
 		members.emplace_back(MemberList::Member{"transfer", TypeProvider::function(strings{"uint"}, strings(), FunctionType::Kind::Transfer, StateMutability::NonPayable)});
-		members.emplace_back(MemberList::Member{"transferToken", TypeProvider::function(strings{"uint", "trcToken"}, strings(), FunctionType::Kind::TransferToken)});
+		members.emplace_back(MemberList::Member{"transferToken", TypeProvider::function(strings{"uint", "trcToken"}, strings(), FunctionType::Kind::TransferToken, StateMutability::NonPayable)});
         members.emplace_back(MemberList::Member{"freeze", TypeProvider::function(strings{"uint", "uint"}, strings(), FunctionType::Kind::Freeze, StateMutability::NonPayable)});
         members.emplace_back(MemberList::Member{"unfreeze", TypeProvider::function(strings{"uint"}, strings(), FunctionType::Kind::Unfreeze, StateMutability::NonPayable)});
         members.emplace_back(MemberList::Member{"delegateResource", TypeProvider::function(strings{"uint", "uint"}, strings(), FunctionType::Kind::DelegateResource, StateMutability::NonPayable)});
@@ -3433,6 +3433,7 @@ std::vector<std::tuple<std::string, Type const*>> FunctionType::makeStackItems()
 	case Kind::BareStaticCall:
 	case Kind::Transfer:
 	case Kind::Send:
+	case Kind::TransferToken:
 		slots = {std::make_tuple("address", TypeProvider::address())};
 		break;
 	case Kind::Internal:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3434,6 +3434,7 @@ std::vector<std::tuple<std::string, Type const*>> FunctionType::makeStackItems()
 	case Kind::Transfer:
 	case Kind::Send:
 	case Kind::TransferToken:
+	case Kind::TokenBalance:
 		slots = {std::make_tuple("address", TypeProvider::address())};
 		break;
 	case Kind::Internal:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3435,6 +3435,9 @@ std::vector<std::tuple<std::string, Type const*>> FunctionType::makeStackItems()
 	case Kind::Send:
 	case Kind::TransferToken:
 	case Kind::TokenBalance:
+	case Kind::Freeze:
+	case Kind::Unfreeze:
+	case Kind::FreezeExpireTime:
 		slots = {std::make_tuple("address", TypeProvider::address())};
 		break;
 	case Kind::Internal:

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -142,13 +142,13 @@ void ContractCompiler::appendCallValueCheck()
 {
 	// Throw if function is not payable but call contained trx.
 	m_context << Instruction::CALLVALUE;
-	m_context.appendConditionalRevert(false, "Ether sent to non-payable function");
+	m_context.appendConditionalRevert(false, "TRX sent to non-payable function");
 
 	m_context << Instruction::CALLTOKENID;
-	m_context.appendConditionalRevert(false, "Ether sent to non-payable function");
+	m_context.appendConditionalRevert(false, "TRC10 sent to non-payable function");
 
 	m_context << Instruction::CALLTOKENVALUE;
-	m_context.appendConditionalRevert(false, "Ether sent to non-payable function");
+	m_context.appendConditionalRevert(false, "TRC10 sent to non-payable function");
 }
 
 void ContractCompiler::appendInitAndConstructorCode(ContractDefinition const& _contract)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1147,9 +1147,9 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::RewardBalance:
 		case FunctionType::Kind::IsSrCandidate:
 		case FunctionType::Kind::VoteCount:
-		case FunctionType::Kind::TotalVoteCount:
-		case FunctionType::Kind::ReceivedVoteCount:
 		case FunctionType::Kind::UsedVoteCount:
+		case FunctionType::Kind::ReceivedVoteCount:
+		case FunctionType::Kind::TotalVoteCount:
         case FunctionType::Kind::GetChainParameter:
         case FunctionType::Kind::AvailableUnfreezeV2Size:
         case FunctionType::Kind::UnfreezableBalanceV2:

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -974,7 +974,9 @@ std::string IRGenerator::deployCode(ContractDefinition const& _contract)
 
 std::string IRGenerator::callValueCheck()
 {
-	return "if callvalue() { " + m_utils.revertReasonIfDebugFunction("Ether sent to non-payable function") + "() }";
+	return "if callvalue() { " + m_utils.revertReasonIfDebugFunction("TRX sent to non-payable function") + "() }\n"
+	+ "if calltokenid() { " + m_utils.revertReasonIfDebugFunction("TRC10 sent to non-payable function") + "() }\n"
+	+ "if calltokenvalue() { " + m_utils.revertReasonIfDebugFunction("TRC10 sent to non-payable function") + "() }";
 }
 
 std::string IRGenerator::dispatchRoutine(ContractDefinition const& _contract)

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -93,7 +93,15 @@ std::string IRGenerator::run(
 	std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
 )
 {
-	return yul::reindent(generate(_contract, _cborMetadata, _otherYulSources));
+	std::string warning =
+		"/*=====================================================*\n"
+		" *                       WARNING                       *\n"
+		" *  Solidity to Yul compilation is still EXPERIMENTAL  *\n"
+		" *       It can result in LOSS OF FUNDS or worse       *\n"
+		" *                !USE AT YOUR OWN RISK!               *\n"
+		" *=====================================================*/\n\n";
+
+	return warning + yul::reindent(generate(_contract, _cborMetadata, _otherYulSources));
 }
 
 std::string IRGenerator::generate(

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1938,6 +1938,10 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			define(_memberAccess) << "caller()\n";
 		else if (member == "value")
 			define(_memberAccess) << "callvalue()\n";
+		else if (member == "tokenvalue")
+			define(_memberAccess) << "calltokenvalue()\n";
+		else if (member == "tokenid")
+			define(_memberAccess) << "calltokenid()\n";
 		else if (member == "origin")
 			define(_memberAccess) << "origin()\n";
 		else if (member == "gasprice")

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1637,11 +1637,11 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 			if lt(<tokenId>, 0xF4240) { revert(0, 0) }
 			let LONG_MAX := sub(exp(2, 63), 1)
 			if gt(<tokenId>, LONG_MAX) { revert(0, 0) }
-			let <retVars> := tokenbalance(<address>, <tokenId>)
+			let <result> := tokenbalance(<address>, <tokenId>)
 		)");
 		templ("address", address);
 		templ("tokenId", tokenId);
-		templ("retVars", IRVariable(_functionCall).commaSeparatedList());
+		templ("result", IRVariable(_functionCall).commaSeparatedList());
 		appendCode() << templ.render();
 
 		break;
@@ -1649,6 +1649,12 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	case FunctionType::Kind::ECRecover:
 	case FunctionType::Kind::RIPEMD160:
 	case FunctionType::Kind::SHA256:
+	case FunctionType::Kind::RewardBalance:
+	case FunctionType::Kind::IsSrCandidate:
+	case FunctionType::Kind::VoteCount:
+	case FunctionType::Kind::UsedVoteCount:
+	case FunctionType::Kind::ReceivedVoteCount:
+	case FunctionType::Kind::TotalVoteCount:
 	{
 		solAssert(!_functionCall.annotation().tryCall);
 		solAssert(!functionType->valueSet());
@@ -1659,6 +1665,12 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 			{FunctionType::Kind::ECRecover, std::make_tuple(1, 0)},
 			{FunctionType::Kind::SHA256, std::make_tuple(2, 0)},
 			{FunctionType::Kind::RIPEMD160, std::make_tuple(3, 12)},
+			{FunctionType::Kind::RewardBalance, std::make_tuple(0x1000005, 0)},
+			{FunctionType::Kind::IsSrCandidate, std::make_tuple(0x1000006, 0)},
+			{FunctionType::Kind::VoteCount, std::make_tuple(0x1000007, 0)},
+			{FunctionType::Kind::UsedVoteCount, std::make_tuple(0x1000008, 0)},
+			{FunctionType::Kind::ReceivedVoteCount, std::make_tuple(0x1000009, 0)},
+			{FunctionType::Kind::TotalVoteCount, std::make_tuple(0x100000a, 0)},
 		};
 		auto [ address, offset ] = precompiles[functionType->kind()];
 		TypePointers argumentTypes;
@@ -1685,7 +1697,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		templ("pos", m_context.newYulVariable());
 		templ("end", m_context.newYulVariable());
 		templ("isECRecover", FunctionType::Kind::ECRecover == functionType->kind());
-		if (FunctionType::Kind::ECRecover == functionType->kind())
+		if (FunctionType::Kind::SHA256 != functionType->kind() && FunctionType::Kind::RIPEMD160 != functionType->kind())
 			templ("encodeArgs", m_context.abiFunctions().tupleEncoder(argumentTypes, parameterTypes));
 		else
 			templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
@@ -1706,6 +1718,75 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		}
 
 		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::Freeze:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string resource{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if iszero(nativefreeze(<address>, <value>, <resource>)) { revert(0, 0) }
+		)");
+		templ("address", address);
+		templ("value", value);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::Unfreeze:
+	{
+		solAssert(arguments.size() == 1 && parameterTypes.size() == 1);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string resource{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		Whiskers templ(R"(
+			if iszero(nativeunfreeze(<address>, <resource>)) { revert(0, 0) }
+		)");
+		templ("address", address);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::FreezeExpireTime:
+	{
+		solAssert(arguments.size() == 1 && parameterTypes.size() == 1);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string resource{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		Whiskers templ(R"(
+			let <result> := nativefreezeexpiretime(<address>, <resource>)
+		)");
+		templ("address", address);
+		templ("resource", resource);
+		templ("result", IRVariable(_functionCall).commaSeparatedList());
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::Vote:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string sr{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string tp{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			let <sr_offset> := <sr>
+			let <tp_offset> := <tp>
+			if iszero(nativevote(mload(<tp_offset>), <tp_offset>, mload(<sr_offset>), <sr_offset>)) { revert(0, 0) }
+		)");
+		templ("sr_offset", m_context.newYulVariable());
+		templ("tp_offset", m_context.newYulVariable());
+		templ("sr", sr);
+		templ("tp", tp);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::WithdrawReward:
+	{
+		define(_functionCall) << "nativewithdrawreward()\n";
 
 		break;
 	}
@@ -1854,7 +1935,13 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
 		}
-		else if (std::set<std::string>{"tokenBalance", "call", "callcode", "delegatecall", "staticcall"}.count(member))
+		else if (std::set<std::string>{"freeze", "unfreeze"}.count(member))
+		{
+			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
+			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
+		}
+		else if (std::set<std::string>{"tokenBalance", "call", "callcode", "delegatecall", "staticcall",
+			"freezeExpireTime"}.count(member))
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
 		else
 			solAssert(false, "Invalid member access to address");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1918,8 +1918,64 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			);
 		break;
 	case Type::Category::Magic:
+	{
 		// we can ignore the kind of magic and only look at the name of the member
-		if (member == "coinbase")
+		Whiskers routine(R"(
+			// load free mem ptr
+			let <ptr> := mload(64)
+			// save index param to mem
+			mstore(<ptr>, <index>)
+			// do static call to get chain parameter, if return zero, revert
+			if iszero(staticcall(gas(), 0x100000b, <ptr>, 32, <ptr>, 32)) {
+				let pos := mload(64)
+				returndatacopy(pos, 0, returndatasize())
+				revert(pos, returndatasize())
+			}
+			// finalize the mem allocation
+			mstore(64, add(<ptr>, 32))
+            // return data size must be exactly 32 bytes
+            if iszero(eq(returndatasize(), 32)) { revert(0, 0) }
+			// load the return value
+			let <result> := mload(<ptr>)
+			// do check the value is a valid uint64
+			if iszero(eq(<result>, and(<result>, 0xffffffffffffffff))) { revert(0, 0) }
+		)");
+		if (member == "totalNetLimit")
+		{
+			routine("ptr", m_context.newYulVariable());
+			routine("index", "1");
+			routine("result", IRVariable(_memberAccess).commaSeparatedList());
+			appendCode() << routine.render();
+		}
+		else if (member == "totalNetWeight")
+		{
+			routine("ptr", m_context.newYulVariable());
+			routine("index", "2");
+			routine("result", IRVariable(_memberAccess).commaSeparatedList());
+			appendCode() << routine.render();
+		}
+		else if (member == "totalEnergyCurrentLimit")
+		{
+			routine("ptr", m_context.newYulVariable());
+			routine("index", "3");
+			routine("result", IRVariable(_memberAccess).commaSeparatedList());
+			appendCode() << routine.render();
+		}
+		else if (member == "totalEnergyWeight")
+		{
+			routine("ptr", m_context.newYulVariable());
+			routine("index", "4");
+			routine("result", IRVariable(_memberAccess).commaSeparatedList());
+			appendCode() << routine.render();
+		}
+		else if (member == "unfreezeDelayDays")
+		{
+			routine("ptr", m_context.newYulVariable());
+			routine("index", "5");
+			routine("result", IRVariable(_memberAccess).commaSeparatedList());
+			appendCode() << routine.render();
+		}
+		else if (member == "coinbase")
 			define(_memberAccess) << "coinbase()\n";
 		else if (member == "timestamp")
 			define(_memberAccess) << "timestamp()\n";
@@ -2024,13 +2080,14 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			define(_memberAccess) << requestedValue << "\n";
 		}
 		else if (std::set<std::string>{"encode", "encodePacked", "encodeWithSelector", "encodeCall", "encodeWithSignature", "decode",
-                             "totalNetLimit", "totalNetWeight", "totalEnergyCurrentLimit", "totalEnergyWeight","unfreezeDelayDays"}.count(member))
+							 "totalNetLimit", "totalNetWeight", "totalEnergyCurrentLimit", "totalEnergyWeight","unfreezeDelayDays"}.count(member))
 		{
 			// no-op
 		}
 		else
 			solAssert(false, "Unknown magic member.");
 		break;
+	}
 	case Type::Category::Struct:
 	{
 		auto const& structType = dynamic_cast<StructType const&>(*_memberAccess.expression().annotation().type);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2079,8 +2079,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 
 			define(_memberAccess) << requestedValue << "\n";
 		}
-		else if (std::set<std::string>{"encode", "encodePacked", "encodeWithSelector", "encodeCall", "encodeWithSignature", "decode",
-							 "totalNetLimit", "totalNetWeight", "totalEnergyCurrentLimit", "totalEnergyWeight","unfreezeDelayDays"}.count(member))
+		else if (std::set<std::string>{"encode", "encodePacked", "encodeWithSelector", "encodeCall", "encodeWithSignature", "decode"}.count(member))
 		{
 			// no-op
 		}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1602,6 +1602,32 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 
 		break;
 	}
+	case FunctionType::Kind::TransferToken:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string tokenValue{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string tokenId{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if lt(<tokenId>, 0xF4240) { revert(0, 0) }
+			let LONG_MAX := sub(exp(2, 63), 1)
+			if gt(<tokenId>, LONG_MAX) { revert(0, 0) }
+			let <gas> := 0
+			if iszero(<tokenValue>) { <gas> := <callStipend> }
+			let <success> := calltoken(<gas>, <address>, <tokenValue>, <tokenId>, 0, 0, 0, 0)
+			if iszero(<success>) { <forwardingRevert>() }
+		)");
+		templ("gas", m_context.newYulVariable());
+		templ("callStipend", toString(evmasm::GasCosts::callStipend));
+		templ("address", address);
+		templ("tokenValue", tokenValue);
+		templ("tokenId", tokenId);
+		templ("success", m_context.newYulVariable());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+		appendCode() << templ.render();
+
+		break;
+	}
 	case FunctionType::Kind::ECRecover:
 	case FunctionType::Kind::RIPEMD160:
 	case FunctionType::Kind::SHA256:
@@ -1805,7 +1831,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 				"isContract(" <<
 				expressionAsType(_memberAccess.expression(), *TypeProvider::address()) <<
 				")\n";
-		else if (std::set<std::string>{"send", "transfer"}.count(member))
+		else if (std::set<std::string>{"send", "transfer", "transferToken"}.count(member))
 		{
 			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
@@ -2158,6 +2184,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 				case FunctionType::Kind::ECRecover:
 				case FunctionType::Kind::SHA256:
 				case FunctionType::Kind::RIPEMD160:
+				case FunctionType::Kind::TransferToken:
 				default:
 					solAssert(false, "unsupported member function");
 				}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1649,12 +1649,6 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	case FunctionType::Kind::ECRecover:
 	case FunctionType::Kind::RIPEMD160:
 	case FunctionType::Kind::SHA256:
-	case FunctionType::Kind::RewardBalance:
-	case FunctionType::Kind::IsSrCandidate:
-	case FunctionType::Kind::VoteCount:
-	case FunctionType::Kind::UsedVoteCount:
-	case FunctionType::Kind::ReceivedVoteCount:
-	case FunctionType::Kind::TotalVoteCount:
 	{
 		solAssert(!_functionCall.annotation().tryCall);
 		solAssert(!functionType->valueSet());
@@ -1665,12 +1659,6 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 			{FunctionType::Kind::ECRecover, std::make_tuple(1, 0)},
 			{FunctionType::Kind::SHA256, std::make_tuple(2, 0)},
 			{FunctionType::Kind::RIPEMD160, std::make_tuple(3, 12)},
-			{FunctionType::Kind::RewardBalance, std::make_tuple(0x1000005, 0)},
-			{FunctionType::Kind::IsSrCandidate, std::make_tuple(0x1000006, 0)},
-			{FunctionType::Kind::VoteCount, std::make_tuple(0x1000007, 0)},
-			{FunctionType::Kind::UsedVoteCount, std::make_tuple(0x1000008, 0)},
-			{FunctionType::Kind::ReceivedVoteCount, std::make_tuple(0x1000009, 0)},
-			{FunctionType::Kind::TotalVoteCount, std::make_tuple(0x100000a, 0)},
 		};
 		auto [ address, offset ] = precompiles[functionType->kind()];
 		TypePointers argumentTypes;
@@ -1697,7 +1685,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		templ("pos", m_context.newYulVariable());
 		templ("end", m_context.newYulVariable());
 		templ("isECRecover", FunctionType::Kind::ECRecover == functionType->kind());
-		if (FunctionType::Kind::SHA256 != functionType->kind() && FunctionType::Kind::RIPEMD160 != functionType->kind())
+		if (FunctionType::Kind::ECRecover == functionType->kind())
 			templ("encodeArgs", m_context.abiFunctions().tupleEncoder(argumentTypes, parameterTypes));
 		else
 			templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
@@ -1790,6 +1778,170 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 
 		break;
 	}
+	case FunctionType::Kind::FreezeBalanceV2:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string resource{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if iszero(nativefreezebalancev2(<value>, <resource>)) { revert(0, 0) }
+		)");
+		templ("value", value);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::UnfreezeBalanceV2:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string resource{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if iszero(nativeunfreezebalancev2(<value>, <resource>)) { revert(0, 0) }
+		)");
+		templ("value", value);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::CancelAllUnfreezeV2:
+	{
+		define(_functionCall) << "nativecancelallunfreezev2()\n";
+
+		break;
+	}
+	case FunctionType::Kind::WithdrawExpireUnfreeze:
+	{
+		define(_functionCall) << "nativewithdrawexpireunfreeze()\n";
+
+		break;
+	}
+	case FunctionType::Kind::DelegateResource:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string resource{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if iszero(nativedelegateresource(<address>, <value>, <resource>)) { revert(0, 0) }
+		)");
+		templ("address", address);
+		templ("value", value);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::UnDelegateResource:
+	{
+		solAssert(arguments.size() == 2 && parameterTypes.size() == 2);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		std::string resource{expressionAsType(*arguments[1], *(parameterTypes[1]))};
+		Whiskers templ(R"(
+			if iszero(nativeundelegateresource(<address>, <value>, <resource>)) { revert(0, 0) }
+		)");
+		templ("address", address);
+		templ("value", value);
+		templ("resource", resource);
+		appendCode() << templ.render();
+
+		break;
+	}
+	case FunctionType::Kind::RewardBalance:
+	case FunctionType::Kind::IsSrCandidate:
+	case FunctionType::Kind::VoteCount:
+	case FunctionType::Kind::UsedVoteCount:
+	case FunctionType::Kind::ReceivedVoteCount:
+	case FunctionType::Kind::TotalVoteCount:
+	case FunctionType::Kind::GetChainParameter:
+	case FunctionType::Kind::AvailableUnfreezeV2Size:
+	case FunctionType::Kind::UnfreezableBalanceV2:
+	case FunctionType::Kind::ExpireUnfreezeBalanceV2:
+	case FunctionType::Kind::DelegatableResource:
+	case FunctionType::Kind::ResourceV2:
+	case FunctionType::Kind::CheckUnDelegateResource:
+	case FunctionType::Kind::ResourceUsage:
+	case FunctionType::Kind::TotalResource:
+	case FunctionType::Kind::TotalDelegatedResource:
+	case FunctionType::Kind::TotalAcquiredResource:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		if (functionType->kind() < FunctionType::Kind::AvailableUnfreezeV2Size)
+			solAssert(!functionType->hasBoundFirstArgument());
+
+		static std::map<FunctionType::Kind, u256> precompiles = {
+			{FunctionType::Kind::RewardBalance, 0x1000005},
+			{FunctionType::Kind::IsSrCandidate, 0x1000006},
+			{FunctionType::Kind::VoteCount, 0x1000007},
+			{FunctionType::Kind::UsedVoteCount, 0x1000008},
+			{FunctionType::Kind::ReceivedVoteCount, 0x1000009},
+			{FunctionType::Kind::TotalVoteCount, 0x100000a},
+			{FunctionType::Kind::GetChainParameter, 0x100000b},
+			{FunctionType::Kind::AvailableUnfreezeV2Size, 0x100000c},
+			{FunctionType::Kind::UnfreezableBalanceV2, 0x100000d},
+			{FunctionType::Kind::ExpireUnfreezeBalanceV2, 0x100000e},
+			{FunctionType::Kind::DelegatableResource, 0x100000f},
+			{FunctionType::Kind::ResourceV2, 0x1000010},
+			{FunctionType::Kind::CheckUnDelegateResource, 0x1000011},
+			{FunctionType::Kind::ResourceUsage, 0x1000012},
+			{FunctionType::Kind::TotalResource, 0x1000013},
+			{FunctionType::Kind::TotalDelegatedResource, 0x1000014},
+			{FunctionType::Kind::TotalAcquiredResource, 0x1000015},
+		};
+		u256 address = precompiles[functionType->kind()];
+		TypePointers argumentTypes;
+		std::vector<std::string> argumentStrings;
+
+		ReturnInfo const returnInfo{m_context.evmVersion(), *functionType};
+
+		if (functionType->hasBoundFirstArgument())
+		{
+			parameterTypes.insert(parameterTypes.begin(), functionType->selfType());
+			argumentTypes.emplace_back(functionType->selfType());
+			argumentStrings += IRVariable(_functionCall.expression()).part("self").stackSlots();
+		}
+
+		for (auto const& arg: arguments)
+		{
+			argumentTypes.emplace_back(&type(*arg));
+			argumentStrings += IRVariable(*arg).stackSlots();
+		}
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			let <end> := <encodeArgs>(<pos> <argumentString>)
+
+			let <success> := staticcall(gas(), <address>, <pos>, sub(<end>, <pos>), <pos>, <returnDataSize>)
+
+			if iszero(<success>) { <forwardingRevert>() }
+
+			// update freeMemoryPointer according to dynamic return size
+			<finalizeAllocation>(<pos>, <returnDataSize>)
+
+			let <retVars> := <abiDecode>(<pos>, add(<pos>, <returnDataSize>))
+		)");
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("end", m_context.newYulVariable());
+		templ("encodeArgs", m_context.abiFunctions().tupleEncoder(argumentTypes, parameterTypes));
+		templ("argumentString", joinHumanReadablePrefixed(argumentStrings));
+		templ("address", toString(address));
+		templ("success", m_context.newYulVariable());
+		templ("retVars", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+
+		templ("abiDecode", m_context.abiFunctions().tupleDecoder(returnInfo.returnTypes, true));
+		templ("returnDataSize", std::to_string(returnInfo.estimatedReturnSize));
+		templ("finalizeAllocation", m_utils.finalizeAllocationFunction());
+
+		appendCode() << templ.render();
+
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}
@@ -1856,7 +2008,17 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			);
 		else if (
 			memberFunctionType->kind() == FunctionType::Kind::ArrayPush ||
-			memberFunctionType->kind() == FunctionType::Kind::ArrayPop
+			memberFunctionType->kind() == FunctionType::Kind::ArrayPop ||
+			memberFunctionType->kind() == FunctionType::Kind::AvailableUnfreezeV2Size ||
+			memberFunctionType->kind() == FunctionType::Kind::UnfreezableBalanceV2 ||
+			memberFunctionType->kind() == FunctionType::Kind::ExpireUnfreezeBalanceV2 ||
+			memberFunctionType->kind() == FunctionType::Kind::DelegatableResource ||
+			memberFunctionType->kind() == FunctionType::Kind::ResourceV2 ||
+			memberFunctionType->kind() == FunctionType::Kind::CheckUnDelegateResource ||
+			memberFunctionType->kind() == FunctionType::Kind::ResourceUsage ||
+			memberFunctionType->kind() == FunctionType::Kind::TotalResource ||
+			memberFunctionType->kind() == FunctionType::Kind::TotalDelegatedResource ||
+			memberFunctionType->kind() == FunctionType::Kind::TotalAcquiredResource
 		)
 		{
 			// Nothing to do.
@@ -1935,7 +2097,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
 		}
-		else if (std::set<std::string>{"freeze", "unfreeze"}.count(member))
+		else if (std::set<std::string>{"freeze", "unfreeze", "delegateResource", "unDelegateResource"}.count(member))
 		{
 			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1628,6 +1628,24 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 
 		break;
 	}
+	case FunctionType::Kind::TokenBalance:
+	{
+		solAssert(arguments.size() == 1 && parameterTypes.size() == 1);
+		std::string address{IRVariable(_functionCall.expression()).part("address").name()};
+		std::string tokenId{expressionAsType(*arguments[0], *(parameterTypes[0]))};
+		Whiskers templ(R"(
+			if lt(<tokenId>, 0xF4240) { revert(0, 0) }
+			let LONG_MAX := sub(exp(2, 63), 1)
+			if gt(<tokenId>, LONG_MAX) { revert(0, 0) }
+			let <retVars> := tokenbalance(<address>, <tokenId>)
+		)");
+		templ("address", address);
+		templ("tokenId", tokenId);
+		templ("retVars", IRVariable(_functionCall).commaSeparatedList());
+		appendCode() << templ.render();
+
+		break;
+	}
 	case FunctionType::Kind::ECRecover:
 	case FunctionType::Kind::RIPEMD160:
 	case FunctionType::Kind::SHA256:
@@ -1836,7 +1854,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			solAssert(dynamic_cast<AddressType const&>(*_memberAccess.expression().annotation().type).stateMutability() == StateMutability::Payable);
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
 		}
-		else if (std::set<std::string>{"call", "callcode", "delegatecall", "staticcall"}.count(member))
+		else if (std::set<std::string>{"tokenBalance", "call", "callcode", "delegatecall", "staticcall"}.count(member))
 			define(IRVariable{_memberAccess}.part("address"), _memberAccess.expression());
 		else
 			solAssert(false, "Invalid member access to address");

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -621,11 +621,12 @@ General Information)").c_str(),
 	outputOptions.add_options()
 		(
 			g_strExperimentalViaIR.c_str(),
-			"Deprecated synonym of --via-ir."
+			"Turn on experimental compilation mode via the IR (EXPERIMENTAL)."
 		)
 		(
 			g_strViaIR.c_str(),
-			"Turn on compilation mode via the IR."
+			("Turn on compilation mode via the IR. (NOTICE: Compilation mode via the IR is currently in experimental. "
+				 "Please use --" + g_strExperimentalViaIR + " as a substitute.)").c_str()
 		)
 		(
 			g_strRevertStrings.c_str(),
@@ -751,10 +752,10 @@ General Information)").c_str(),
 		(CompilerOutputs::componentName(&CompilerOutputs::binary).c_str(), "Binary of the contracts in hex.")
 		(CompilerOutputs::componentName(&CompilerOutputs::binaryRuntime).c_str(), "Binary of the runtime part of the contracts in hex.")
 		(CompilerOutputs::componentName(&CompilerOutputs::abi).c_str(), "ABI specification of the contracts.")
-		(CompilerOutputs::componentName(&CompilerOutputs::ir).c_str(), "Intermediate Representation (IR) of all contracts.")
-		(CompilerOutputs::componentName(&CompilerOutputs::irAstJson).c_str(), "AST of Intermediate Representation (IR) of all contracts in a compact JSON format.")
-		(CompilerOutputs::componentName(&CompilerOutputs::irOptimized).c_str(), "Optimized Intermediate Representation (IR) of all contracts.")
-		(CompilerOutputs::componentName(&CompilerOutputs::irOptimizedAstJson).c_str(), "AST of optimized Intermediate Representation (IR) of all contracts in a compact JSON format.")
+		(CompilerOutputs::componentName(&CompilerOutputs::ir).c_str(), "Intermediate Representation (IR) of all contracts (EXPERIMENTAL).")
+		(CompilerOutputs::componentName(&CompilerOutputs::irAstJson).c_str(), "AST of Intermediate Representation (IR) of all contracts in a compact JSON format (EXPERIMENTAL).")
+		(CompilerOutputs::componentName(&CompilerOutputs::irOptimized).c_str(), "Optimized Intermediate Representation (IR) of all contracts (EXPERIMENTAL).")
+		(CompilerOutputs::componentName(&CompilerOutputs::irOptimizedAstJson).c_str(), "AST of optimized Intermediate Representation (IR) of all contracts in a compact JSON format (EXPERIMENTAL).")
 		(CompilerOutputs::componentName(&CompilerOutputs::signatureHashes).c_str(), "Function signature hashes of the contracts.")
 		(CompilerOutputs::componentName(&CompilerOutputs::natspecUser).c_str(), "Natspec user documentation of all contracts.")
 		(CompilerOutputs::componentName(&CompilerOutputs::natspecDev).c_str(), "Natspec developer documentation of all contracts.")
@@ -1425,6 +1426,12 @@ void CommandLineParser::processArgs()
 		m_args.count(g_strModelCheckerSolvers) ||
 		m_args.count(g_strModelCheckerTargets) ||
 		m_args.count(g_strModelCheckerTimeout);
+	if (m_args.count(g_strViaIR) > 0) {
+		solThrow(
+			CommandLineValidationError,
+			"Compilation mode via the IR is experimental now. Use --"  + g_strExperimentalViaIR + "."
+		);
+	}
 	m_options.output.viaIR = (m_args.count(g_strExperimentalViaIR) > 0 || m_args.count(g_strViaIR) > 0);
 
 	solAssert(

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -617,16 +617,15 @@ General Information)").c_str(),
 				"Select desired EOF version. Currently the only valid value is 1. "
 				"If not specified, legacy non-EOF bytecode will be generated."
 			)
+			(
+				g_strViaIR.c_str(),
+				"Turn on compilation mode via the IR."
+			)
 		;
 	outputOptions.add_options()
 		(
 			g_strExperimentalViaIR.c_str(),
 			"Turn on experimental compilation mode via the IR (EXPERIMENTAL)."
-		)
-		(
-			g_strViaIR.c_str(),
-			("Turn on compilation mode via the IR. (NOTICE: Compilation mode via the IR is currently in experimental. "
-				 "Please use --" + g_strExperimentalViaIR + " as a substitute.)").c_str()
 		)
 		(
 			g_strRevertStrings.c_str(),


### PR DESCRIPTION
### Summary of this PR

- **TypeChecker**: Added support for `transferToken` in the `send/transfer` validation logic to ensure calls to non-payable addresses now error correctly.

- **AST (Types.cpp)**: Introduced TRON-native methods—`transferToken`, `freeze`, `unfreeze`, `delegateResource`, `unDelegateResource`, `tokenBalance`, `freezeExpireTime`, etc.—and updated `FunctionType::makeStackItems` to handle their IR operand types.

- **ContractCompiler**: Added new opcodes `CALLTOKENID` and `CALLTOKENVALUE` in call-value checks, and included revert messages for non-payable functions in TRX/TRC10 transactions.

- **ExpressionCompiler:** Extended compilation logic for TRON-specific built-ins (e.g. `AvailableUnfreezeV2Size`, `UnfreezableBalanceV2`, and others).

- **IRGenerator / IRGeneratorForStatements**: Implemented Yul IR generation for the above TRON operations and added an “Experimental” warning banner in the output header.

- **CommandLineParser**: Updated the `--via-ir` help text to label TRON IR support as experimental.