### PR TITLE
fix: disambiguate library functions vs native properties in member access

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3186,6 +3186,46 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				++it;
 	}
 
+	// When both a native property and a library function share the same name,
+	// disambiguate based on call syntax:
+	// - With parentheses (function call): prefer function members (library)
+	// - Without parentheses (property access): prefer non-function members (native)
+	// This mirrors the identifier resolution pattern at lines 3693-3745 where
+	// VariableDeclarations are preferred without parentheses.
+	if (possibleMembers.size() > 1)
+	{
+		bool hasFunction = false;
+		bool hasNonFunction = false;
+		for (auto const& member: possibleMembers)
+		{
+			if (member.type->category() == Type::Category::Function)
+				hasFunction = true;
+			else
+				hasNonFunction = true;
+		}
+
+		if (hasFunction && hasNonFunction)
+		{
+			MemberList::MemberMap filtered;
+			if (arguments)
+			{
+				// Called with parentheses - keep only functions (library)
+				for (auto const& member: possibleMembers)
+					if (member.type->category() == Type::Category::Function)
+						filtered.push_back(member);
+			}
+			else
+			{
+				// Accessed without parentheses - keep only non-functions (native property)
+				for (auto const& member: possibleMembers)
+					if (member.type->category() != Type::Category::Function)
+						filtered.push_back(member);
+			}
+			if (filtered.size() == 1)
+				possibleMembers = std::move(filtered);
+		}
+	}
+
 	annotation.isConstant = false;
 
 	if (possibleMembers.empty())

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that library function is preferred over native property when called with parentheses.
+// This allows OpenZeppelin's Address.isContract() to work alongside Tron's native address.isContract property.
+library Address {
+    function isContract(address account) internal view returns (bool) {
+        return account.code.length > 0;
+    }
+}
+
+contract C {
+    using Address for address;
+
+    function check(address a) public view returns (bool) {
+        // With parentheses - should use library function
+        return a.isContract();
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that native property is preferred over library function when accessed without parentheses.
+// This allows Tron's native address.isContract property to work alongside library functions.
+library Address {
+    function isContract(address account) internal view returns (bool) {
+        return account.code.length > 0;
+    }
+}
+
+contract C {
+    using Address for address;
+
+    function check(address a) public view returns (bool) {
+        // Without parentheses - should use native property
+        return a.isContract;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/memberLookup/native_isContract_property.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/native_isContract_property.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test Tron's native address.isContract property works without library.
+contract C {
+    function check(address a) public view returns (bool) {
+        return a.isContract;
+    }
+}
+// ----


### PR DESCRIPTION
## Summary

This PR fixes an issue where using OpenZeppelin's `Address.isContract()` library function on Tron causes a compilation error:

```
Error: Member "isContract" not unique after argument-dependent lookup in address.
```

This happens because Tron's native `address.isContract` property (added in TIP-44) conflicts with library functions attached via `using Address for address;`.

## Problem

When code uses:
```solidity
using Address for address;
// ...
return a.isContract();  // Error: not unique
```

The compiler finds two members named `isContract`:
1. Tron's native property: `address.isContract` (boolean, uses ISCONTRACT opcode)
2. Library function: `Address.isContract(address)` attached via `using for`

## Solution

Disambiguate based on call syntax:
- **With parentheses** `a.isContract()`: prefer library function
- **Without parentheses** `a.isContract`: prefer native property

This mirrors the existing identifier resolution pattern in `visit(Identifier)` (lines 3693-3745 in TypeChecker.cpp) where `VariableDeclaration`s are preferred without parentheses.

## Changes

- `libsolidity/analysis/TypeChecker.cpp`: Added disambiguation logic after overload resolution
- Added 3 syntax tests in `test/libsolidity/syntaxTests/memberLookup/`:
  - `library_function_vs_native_property_with_parens.sol` - verifies library function is used with `()`
  - `library_function_vs_native_property_without_parens.sol` - verifies native property is used without `()`  
  - `native_isContract_property.sol` - verifies native property still works standalone

## Behavior After Fix

| Syntax | Result |
|--------|--------|
| `addr.isContract()` | Library function (OpenZeppelin compatible) |
| `addr.isContract` | Native Tron property (ISCONTRACT opcode) |

## Motivation

This enables Hyperlane and other protocols using OpenZeppelin contracts to deploy on Tron without modification.