### PR TITLE
fix: disambiguate library functions vs native properties in member access

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3175,12 +3175,18 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	size_t const initialMemberCount = possibleMembers.size();
 	if (initialMemberCount > 1 && arguments)
 	{
-		// do overload resolution
+		// Do overload resolution, and filter out non-functions when called with parentheses.
+		// This allows library functions like OpenZeppelin's Address.isContract() to work
+		// alongside Tron's native address.isContract property.
+		// Mirrors the identifier resolution pattern at lines 3693-3745 where
+		// VariableDeclarations are preferred without parentheses.
 		for (auto it = possibleMembers.begin(); it != possibleMembers.end();)
 			if (
 				it->type->category() == Type::Category::Function &&
 				!dynamic_cast<FunctionType const&>(*it->type).canTakeArguments(*arguments, exprType)
 			)
+				it = possibleMembers.erase(it);
+			else if (it->type->category() != Type::Category::Function)
 				it = possibleMembers.erase(it);
 			else
 				++it;

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that library function is preferred over native property when called with parentheses.
+// This allows OpenZeppelin's Address.isContract() to work alongside Tron's native address.isContract property.
+library Address {
+    function isContract(address account) internal view returns (bool) {
+        return account.code.length > 0;
+    }
+}
+
+contract C {
+    using Address for address;
+
+    function check(address a) public view returns (bool) {
+        // With parentheses - should use library function
+        return a.isContract();
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that accessing a member without parentheses when both a native property
+// and a library function exist with the same name results in an ambiguity error.
+// Users should use the native property syntax directly without "using for" to avoid this.
+library Address {
+    function isContract(address account) internal view returns (bool) {
+        return account.code.length > 0;
+    }
+}
+
+contract C {
+    using Address for address;
+
+    function check(address a) public view returns (bool) {
+        // Without parentheses - ambiguous between native property and library function
+        return a.isContract;
+    }
+}
+// ----
+// TypeError 6675: (519-531): Member "isContract" not unique after argument-dependent lookup in address.

--- a/test/libsolidity/syntaxTests/memberLookup/native_isContract_property.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/native_isContract_property.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test Tron's native address.isContract property works without library.
+contract C {
+    function check(address a) public view returns (bool) {
+        return a.isContract;
+    }
+}
+// ----


### PR DESCRIPTION
## Summary

This PR fixes an issue where using OpenZeppelin's `Address.isContract()` library function on Tron causes a compilation error:

```
Error: Member "isContract" not unique after argument-dependent lookup in address.
```

This happens because Tron's native `address.isContract` property (added in TIP-44) conflicts with library functions attached via `using Address for address;`.

## Problem

When code uses:
```solidity
using Address for address;
// ...
return a.isContract();  // Error: not unique
```

The compiler finds two members named `isContract`:
1. Tron's native property: `address.isContract` (boolean, uses ISCONTRACT opcode)
2. Library function: `Address.isContract(address)` attached via `using for`

## Solution

Disambiguate based on call syntax:
- **With parentheses** `a.isContract()`: prefer library function

Without parentheses (`a.isContract`) remains unchanged and will still error with "not unique" when both a native property and library function exist.

## Changes

- `libsolidity/analysis/TypeChecker.cpp`: Added disambiguation logic to filter out non-functions when called with parentheses
- Added 2 syntax tests in `test/libsolidity/syntaxTests/memberLookup/`:
  - `library_function_vs_native_property_with_parens.sol` - verifies library function is used with `()`
  - `native_isContract_property.sol` - verifies native property still works standalone

## Behavior After Fix

| Syntax | Result |
|--------|--------|
| `addr.isContract()` | ✅ Library function (OpenZeppelin compatible) |
| `addr.isContract` (no `using for`) | ✅ Native Tron property (unchanged) |
| `addr.isContract` (with `using for`) | ❌ "not unique" error (unchanged) |

## Motivation

This enables Hyperlane and other protocols using OpenZeppelin contracts to deploy on Tron without modification.