### PR TITLE
fix(gasmeter): account for new-account and memory gas in TRON instructions

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -223,6 +223,10 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		case Instruction::NATIVEVOTE:
 			gas = GasCosts::voteGas;
+			// NATIVEVOTE reads two memory ranges (see SemanticInformation::readWriteOperations).
+			// With args == 4, the ranges are (offset, size) = (-3, -2) and (-1, 0) on the stack.
+			gas += memoryGas(-3, -2);
+			gas += memoryGas(-1, 0);
 			break;
 		case Instruction::NATIVEWITHDRAWREWARD:
 			gas = GasCosts::withdrawGas;
@@ -231,9 +235,12 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 		case Instruction::NATIVEUNFREEZEBALANCEV2:
 		case Instruction::NATIVECANCELALLUNFREEZEV2:
 		case Instruction::NATIVEWITHDRAWEXPIREUNFREEZE:
+			gas = GasCosts::freezeV2Gas;
+			break;
 		case Instruction::NATIVEDELEGATERESOURCE:
 		case Instruction::NATIVEUNDELEGATERESOURCE:
 			gas = GasCosts::freezeV2Gas;
+			gas += GasCosts::callNewAccountGas; // Delegating to a non-existent address may create a new account.
 			break;
 		case Instruction::CHAINID:
 			gas = runGas(Instruction::CHAINID, m_evmVersion);


### PR DESCRIPTION
## Summary

Two TRON instructions are under-charged in `libevmasm/GasMeter.cpp`, so the optimizer's gas estimates are inconsistent with comparable opcodes. This only affects compile-time gas estimation, not runtime correctness.

## Fixes

- **`NATIVEDELEGATERESOURCE` / `NATIVEUNDELEGATERESOURCE` did not add `callNewAccountGas`.** Delegating resources to a non-existent address may create a new account, exactly like `NATIVEFREEZE` (which already adds it). The two delegation opcodes are split out of the shared Stake-2.0 group and now add `callNewAccountGas`; the other four V2 opcodes have no address operand and stay unchanged.
- **`NATIVEVOTE` did not charge memory-expansion gas.** It reads two memory ranges (per `SemanticInformation::readWriteOperations`), but unlike `KECCAK256` / `LOG*` / `CALL*` / `CREATE*` / `RETURN` it did not add `memoryGas(...)`. The two memory-expansion charges for its argument ranges are now included.

## Verification

`solc` builds cleanly; `vote` and delegate contracts still compile on both the legacy and via-IR pipelines.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
