### PR TITLE
fix(smtchecker): stop ICE on TRON crypto builtins

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -670,12 +670,6 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 		break;
 	case FunctionType::Kind::KECCAK256:
 	case FunctionType::Kind::ECRecover:
-	case FunctionType::Kind::ValidateMultiSign:
-    case FunctionType::Kind::BatchValidateSign:
-    case FunctionType::Kind::VerifyBurnProof:
-    case FunctionType::Kind::VerifyTransferProof:
-    case FunctionType::Kind::VerifyMintProof:
-    case FunctionType::Kind::PedersenHash:
 	case FunctionType::Kind::SHA256:
 	case FunctionType::Kind::RIPEMD160:
 		visitCryptoFunction(_funCall);
@@ -731,6 +725,12 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 	case FunctionType::Kind::BareCallCode:
 	case FunctionType::Kind::BareDelegateCall:
 	default:
+		// The TRON-specific builtins (freeze/unfreeze, vote, the various V2 calls,
+		// validatemultisign/batchvalidatesign, the zk-proof verifiers, pedersenhash, ...)
+		// are not modeled here: we only emit the warning below. Their state side effects
+		// are not havoc'd in this branch; soundness for state mutation across unmodeled
+		// calls is instead handled by the engine-level reset logic (CHC::unknownFunctionCall
+		// / makeOutsideFunctionCall and BMC's resetStateVariables paths).
 		m_unsupportedErrors.warning(
 			4588_error,
 			_funCall.location(),


### PR DESCRIPTION
## Summary

Running the SMTChecker on any contract that calls one of the six TRON crypto/zk builtins crashes the compiler with an internal error.

## Problem

`SMTEncoder::endVisit(FunctionCall)` routes `validatemultisign`, `batchvalidatesign`, `verifyMintProof`, `verifyBurnProof`, `verifyTransferProof` and `pedersenHash` into `visitCryptoFunction()`, but that function only handles `KECCAK256` / `SHA256` / `RIPEMD160` / `ECRecover` and `solAssert(false)`s on anything else — raising an `InternalCompilerError`. As a result `solc --model-checker-engine all` ICEs on, for example, a shielded-TRC20 contract using `verifyMintProof` / `pedersenHash`.

## Fix

Let those six TRON builtins fall through to the `default` branch — the same "Assertion checker does not yet implement this type of function call" warning that the other ~30 TRON builtins already get — instead of routing them into `visitCryptoFunction()`. The four upstream crypto builtins are unaffected.

## Verification

`solc --model-checker-engine all` no longer ICEs on a contract calling `validatemultisign` / `verifyMintProof`; the upstream crypto builtins still go through `visitCryptoFunction`.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
