### PR TITLE
fix(codegen): clean up dead code and order-fragile assertion in TRON paths

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1692,7 +1692,6 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		}
 		case FunctionType::Kind::WithdrawReward:
 		{
-			_functionCall.expression().accept(*this);
 			m_context << Instruction::NATIVEWITHDRAWREWARD;
 			break;
 		}
@@ -1720,13 +1719,11 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		}
         case FunctionType::Kind::CancelAllUnfreezeV2:
         {
-            _functionCall.expression().accept(*this);
             m_context << Instruction::NATIVECANCELALLUNFREEZEV2;
             break;
         }
 		case FunctionType::Kind::WithdrawExpireUnfreeze:
 		{
-			_functionCall.expression().accept(*this);
 			m_context << Instruction::NATIVEWITHDRAWEXPIREUNFREEZE;
 			break;
 		}
@@ -2180,7 +2177,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			);
 		}
 		else if ((std::set<std::string>{"tokenBalance", "call", "callcode", "delegatecall", "staticcall",
-							  "freezeExpireTime", "totalFrozenBalance", "frozenBalance", "frozenBalanceUsage"}).count(member))
+							  "freezeExpireTime"}).count(member))
 			utils().convertType(
 				*_memberAccess.expression().annotation().type,
 				*TypeProvider::address(),

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1904,7 +1904,22 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(!_functionCall.annotation().tryCall);
 		solAssert(!functionType->valueSet());
 		solAssert(!functionType->gasSet());
-		if (functionType->kind() < FunctionType::Kind::AvailableUnfreezeV2Size)
+		// Only the address-member reads in this block carry a bound first argument (the address).
+		// Match them by kind rather than by enum ordering so that reordering FunctionType::Kind
+		// in Types.h cannot silently invalidate this consistency check.
+		static std::set<FunctionType::Kind> const boundFirstArgumentKinds = {
+			FunctionType::Kind::AvailableUnfreezeV2Size,
+			FunctionType::Kind::UnfreezableBalanceV2,
+			FunctionType::Kind::ExpireUnfreezeBalanceV2,
+			FunctionType::Kind::DelegatableResource,
+			FunctionType::Kind::ResourceV2,
+			FunctionType::Kind::CheckUnDelegateResource,
+			FunctionType::Kind::ResourceUsage,
+			FunctionType::Kind::TotalResource,
+			FunctionType::Kind::TotalDelegatedResource,
+			FunctionType::Kind::TotalAcquiredResource,
+		};
+		if (!boundFirstArgumentKinds.count(functionType->kind()))
 			solAssert(!functionType->hasBoundFirstArgument());
 
 		static std::map<FunctionType::Kind, u256> precompiles = {


### PR DESCRIPTION
## Summary

Three zero-impact clean-ups in the TRON code paths of the legacy (`ExpressionCompiler`) and IR (`IRGeneratorForStatements`) code generators. None of these change the generated bytecode for any valid input.

## Changes

- **Drop dead member names (legacy).** The `address` member-access read-set still listed `totalFrozenBalance` / `frozenBalance` / `frozenBalanceUsage`, removed years ago in the V1→V2 stake refactor — unreachable dead code (the IR backend was already clean).
- **Remove no-op `expression().accept()` (legacy).** The zero-argument magic builtins `withdrawreward` / `cancelAllUnfreezeV2` / `withdrawExpireUnfreeze` each ran `_functionCall.expression().accept(*this)`, a no-op for a magic variable (cf. `gasleft`, which does not).
- **Make the IR bound-first-argument assertion order-independent.** The shared precompile-read block asserted `!hasBoundFirstArgument()` via `kind < AvailableUnfreezeV2Size`, relying on the declaration order of `FunctionType::Kind`. Replaced with an explicit set of the bound (address-member-read) kinds, so reordering the enum can no longer silently invalidate the check.

## Verification

`solc` builds cleanly; `withdrawreward` runtime bytecode is byte-identical before and after (the clean-ups are genuine no-ops); `vote` and ordinary contracts compile on both the legacy and via-IR pipelines.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
