### PR TITLE
fix(astimport): accept sun/trx subdenominations in --import-ast

### DIFF
--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -1225,6 +1225,10 @@ Literal::SubDenomination ASTJsonImporter::subdenomination(Json const& _node)
 		return Literal::SubDenomination::Gwei;
 	else if (subDenStr == "ether")
 		return Literal::SubDenomination::Ether;
+	else if (subDenStr == "sun")
+		return Literal::SubDenomination::Sun;
+	else if (subDenStr == "trx")
+		return Literal::SubDenomination::Trx;
 	else if (subDenStr == "seconds")
 		return Literal::SubDenomination::Second;
 	else if (subDenStr == "minutes")


### PR DESCRIPTION
## Summary

`--import-ast` aborts on any contract that uses a TRON `sun` / `trx` literal, because the importer does not recognise those subdenominations.

## The bug

`ASTJsonExporter` serialises the `sun` / `trx` subdenominations (via the generic `TokenTraits::toString`), but `ASTJsonImporter::subdenomination()` hardcodes only the upstream units (`wei` … `years`) and `astAssert(false, "Unknown subdenomination")` on anything else. So exporting and re-importing a contract with a TRX literal fails:

```solidity
contract C {
    function f() public pure returns (uint) {
        return 1 trx;
    }
}
```

```
$ solc --import-ast export.json
Error: Failed to import AST: Unknown subdenomination
```

This breaks any AST round-trip tooling (`--ast-compact-json` → `--import-ast`) for TRON contracts using `trx` / `sun` units.

## The fix

Add the `sun` and `trx` cases to `ASTJsonImporter::subdenomination()`, mapping to `Literal::SubDenomination::Sun` / `Trx` — the same enum values the exporter already emits — placed alongside `ether` to mirror the export ordering.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
