### PR TITLE
fix(analysis): improve TRON builtin diagnostics, drop dead via-ir branch

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3139,14 +3139,22 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 			else if (auto const* addressType = dynamic_cast<AddressType const*>(exprType))
 			{
 				// Trigger error when using send or transfer with a non-payable fallback function.
-				if (memberName == "send" || memberName == "transfer" || memberName == "transferToken")
+				if (
+					memberName == "send" ||
+					memberName == "transfer" ||
+					memberName == "transferToken" ||
+					memberName == "freeze" ||
+					memberName == "unfreeze" ||
+					memberName == "delegateResource" ||
+					memberName == "unDelegateResource"
+				)
 				{
 					solAssert(
 						addressType->stateMutability() != StateMutability::Payable,
 						"Expected address not-payable as members were not found"
 					);
 
-					return { 9862_error, "\"send\", \"transfer\" and \"transferToken\" are only available for objects of type \"address payable\", not \"" + exprType->humanReadableName() + "\"." };
+					return { 9862_error, "\"send\", \"transfer\", \"transferToken\", \"freeze\", \"unfreeze\", \"delegateResource\" and \"unDelegateResource\" are only available for objects of type \"address payable\", not \"" + exprType->humanReadableName() + "\"." };
 				}
 			}
 

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -286,8 +286,8 @@ void ViewPureChecker::reportMutability(
 					5887_error,
 					_location,
 					m_currentFunction->isConstructor()  ?
-						"\"msg.value\" and \"callvalue()\" can only be used in payable constructors. Make the constructor \"payable\" to avoid this error."
-						: "\"msg.value\" and \"callvalue()\" can only be used in payable public functions. Make the function \"payable\" or use an internal function to avoid this error."
+						"\"msg.value\", \"msg.tokenid\", \"msg.tokenvalue\" and \"callvalue()\" can only be used in payable constructors. Make the constructor \"payable\" to avoid this error."
+						: "\"msg.value\", \"msg.tokenid\", \"msg.tokenvalue\" and \"callvalue()\" can only be used in payable public functions. Make the function \"payable\" or use an internal function to avoid this error."
 				);
 			m_errors = true;
 		}

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -1450,7 +1450,7 @@ void CommandLineParser::processArgs()
 			"The --" + g_strViaIR + " is currently experimental for TRON solidity compiler. Use --" + g_strExperimentalViaIR + " instead."
 		);
 	}
-	m_options.output.viaIR = (m_args.count(g_strExperimentalViaIR) > 0 || m_args.count(g_strViaIR) > 0);
+	m_options.output.viaIR = (m_args.count(g_strExperimentalViaIR) > 0);
 
 	solAssert(
 		m_options.input.mode == InputMode::Compiler ||


### PR DESCRIPTION
## Summary

Two diagnostic improvements for TRON builtins and one dead-code removal in the analysis / CLI layer. No change to the generated bytecode.

## Changes

- **`address payable` hint covers all payable-only TRON members (TypeChecker).** The 9862 *"only available for objects of type address payable"* hint listed only `send` / `transfer` / `transferToken`, but `freeze` / `unfreeze` / `delegateResource` / `unDelegateResource` are payable-only members too. Calling one of them on a plain `address` previously fell back to the generic 9582 *"member not found"*; now it gives the helpful "use address payable" hint.
- **payable-only error mentions `msg.tokenid` / `msg.tokenvalue` (ViewPureChecker).** `msg.tokenid` and `msg.tokenvalue` are classified as payable (correctly), but the 5887 error text was hardcoded to `"msg.value" and "callvalue()"`. Reading `msg.tokenid` in a non-payable function therefore reported a misleading `msg.value` message; the text now lists the TRON members as well.
- **Remove unreachable `--via-ir` branch (CommandLineParser).** After `--via-ir` is unconditionally rejected with `solThrow`, the `|| m_args.count(g_strViaIR) > 0` term in the following assignment is dead. Removed.

## Verification

- A plain `address` calling `freeze(...)` now reports error 9862 (the "address payable" hint) instead of the generic 9582.
- Reading `msg.tokenid` in a non-payable function reports an error that names `msg.tokenid` / `msg.tokenvalue`, not just `msg.value`.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
