### PR TITLE
Revert "fix(gasmeter): account for new-account and memory gas in TRON instructions"

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -223,10 +223,6 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		case Instruction::NATIVEVOTE:
 			gas = GasCosts::voteGas;
-			// NATIVEVOTE reads two memory ranges (see SemanticInformation::readWriteOperations).
-			// With args == 4, the ranges are (offset, size) = (-3, -2) and (-1, 0) on the stack.
-			gas += memoryGas(-3, -2);
-			gas += memoryGas(-1, 0);
 			break;
 		case Instruction::NATIVEWITHDRAWREWARD:
 			gas = GasCosts::withdrawGas;
@@ -235,12 +231,9 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 		case Instruction::NATIVEUNFREEZEBALANCEV2:
 		case Instruction::NATIVECANCELALLUNFREEZEV2:
 		case Instruction::NATIVEWITHDRAWEXPIREUNFREEZE:
-			gas = GasCosts::freezeV2Gas;
-			break;
 		case Instruction::NATIVEDELEGATERESOURCE:
 		case Instruction::NATIVEUNDELEGATERESOURCE:
 			gas = GasCosts::freezeV2Gas;
-			gas += GasCosts::callNewAccountGas; // Delegating to a non-existent address may create a new account.
 			break;
 		case Instruction::CHAINID:
 			gas = runGas(Instruction::CHAINID, m_evmVersion);


### PR DESCRIPTION
## Summary

Reverts the gas-metering changes introduced in #120 (commit `abbdee3`), restoring `libevmasm/GasMeter.cpp` to its prior state.

This reverts:
- The two `memoryGas(...)` charges added to `NATIVEVOTE`.
- Splitting `NATIVEDELEGATERESOURCE` / `NATIVEUNDELEGATERESOURCE` out of the shared Stake-2.0 group to add `callNewAccountGas`.

The six V2 opcodes are merged back into the single `freezeV2Gas` branch, and `NATIVEVOTE` is back to charging only `voteGas`.

Note: #120 only affected compile-time gas estimation in the optimizer, not runtime correctness — so this revert likewise has no effect on generated bytecode semantics.

Clean revert: no commit after #120 touched this file. `solc` builds cleanly.

Targets `release_0.8.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)