### PR TITLE
fix(ci): bump linux/ems build images to unblock v0.8.29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,12 +80,14 @@ jobs:
     runs-on: [ self-hosted, Linux, for-linux ]
 
     env:
-      CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DUSE_Z3_DLOPEN=ON -DUSE_CVC4=OFF -DSOLC_STATIC_STDLIBS=ON
+      CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DSOLC_LINK_STATIC=ON
+      TERM: xterm
       MAKEFLAGS: -j 10
       CPUs: 10
 
     container:
-      image: solbuildpackpusher/solidity-buildpack-deps@sha256:84a1fb8771236e8d9aa5c615a425b8929e56a6e4f150a60078c8d74a1ceaa6c2
+      # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-3
+      image: solbuildpackpusher/solidity-buildpack-deps@sha256:ef6a91d7f1434c67fb9e05c6136d80f71c0ad9198479e1a88e3437680993cda4
 
     steps:
       - name: Checkout code
@@ -112,11 +114,14 @@ jobs:
     runs-on: [ self-hosted, Linux, for-ems ]
 
     env:
+      TERM: xterm
       MAKEFLAGS: -j 10
       CPUs: 5
 
     container:
-      image: solbuildpackpusher/solidity-buildpack-deps@sha256:c57f2bfb8c15d70fe290629358dd1c73dc126e3760f443b54764797556b887d4
+      # solbuildpackpusher/solidity-buildpack-deps:emscripten-20
+      # NOTE: Keep in sync with the digest in scripts/build_emscripten.sh
+      image: solbuildpackpusher/solidity-buildpack-deps@sha256:98f963ed799a0d206ef8e7b5475f847e0dea53b7fdea9618bbc6106a62730bd2
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The `Build binaries on multi platform` workflow fails on `release_0.8.29` ([run 29002760313](https://github.com/tronprotocol/solidity/actions/runs/29002760313)). `b_linux` and `b_ems` both die in `Run build script`; `b_macos` and `b_windows` pass because they have no container.

Both container images are pinned by digest and had gone stale relative to what v0.8.29 requires — but for two *different* reasons:

| Job | Pinned image | Ships | v0.8.29 requires | Fails at |
|---|---|---|---|---|
| `b_linux` | `sha256:84a1fb87…` | GCC **9.4.0** | g++ **>= 11.0** | `cmake/EthCompilerSettings.cmake:94` |
| `b_ems` | `sha256:c57f2bfb…` | Z3 **4.12.1** | Z3 **== 4.13.3** | `CMakeLists.txt:107` (`STRICT_Z3_VERSION` defaults to `ON`) |

The Z3 gate only lives in the emscripten branch, so it hits `b_ems` alone. Neither failure is a compiler-13 issue.

## Fix

Bump both digests to the ones upstream v0.8.29 uses (from `.circleci/config.yml` `parameters`):

- `b_linux` → `sha256:ef6a91d7…` (`ubuntu2404-3`, gcc-13)
- `b_ems` → `sha256:98f963ed…` (`emscripten-20`, builds `z3-4.13.3` per `scripts/docker/buildpack-deps/Dockerfile.emscripten:52`)

Note `scripts/build_emscripten.sh:40` already pins `sha256:98f963ed…` — it came in with the v0.8.29 merge, so `build.yml` was out of sync with our own tree. A comment now marks the two places to keep together.

## Also: `b_linux` CMAKE_OPTIONS

`-DUSE_Z3_DLOPEN=ON -DUSE_CVC4=OFF -DSOLC_STATIC_STDLIBS=ON` was copied verbatim from upstream's `b_ubu_static` back in `7308abc08` (first released in v0.8.0) and never updated since. Upstream has moved on three times:

- `b8ba5da12` (v0.8.27) — CVC4 → cvc5, `USE_CVC4` gone
- `c8d9fc3fb` (v0.8.29) — z3 dlopen removed, `USE_Z3_DLOPEN` gone
- `eceea8222` (v0.8.29) — back to a fully static build: `SOLC_STATIC_STDLIBS` → `SOLC_LINK_STATIC`, image bumped to ubuntu 2404

So as of the v0.8.29 merge, `USE_Z3_DLOPEN` and `USE_CVC4` no longer exist in the project (0 hits tree-wide) and are silently ignored. This PR replays upstream's `eceea8222` on our side: `-DCMAKE_BUILD_TYPE=Release -DSOLC_LINK_STATIC=ON`.

**Why this matters:** `SOLC_LINK_STATIC` (`-static`) and `SOLC_STATIC_STDLIBS` (`-static-libgcc -static-libstdc++` only) are an `if/elseif` in `solc/CMakeLists.txt:18-33`. Keeping `SOLC_STATIC_STDLIBS` while moving to the 24.04 image would leave `solc-static-linux` dynamically linked against glibc 2.39 — unrunnable on older distros, despite the name. Upstream dropped dlopen precisely so it could go fully static again in the same release.

`TERM: xterm` added to both jobs to match upstream's env. `b_macos` / `b_windows` env already matches upstream exactly and is untouched.

## Verification

- Error line numbers in the real job logs match the actual code (`EthCompilerSettings.cmake:94`, `CMakeLists.txt:107`)
- New digests are exactly upstream v0.8.29's; `emscripten-20` is confirmed to build `z3-4.13.3`
- `build.yml` still parses; all 5 jobs intact
- Upstream runs `SOLC_LINK_STATIC=ON` on this same `ubuntu2404-3` image, so the combination is already proven

Real validation is this workflow going green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)