### PR TITLE
ci: sync GitHub build images with CircleCI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,8 @@ jobs:
       CPUs: 10
 
     container:
-      # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-3
-      image: solbuildpackpusher/solidity-buildpack-deps@sha256:ef6a91d7f1434c67fb9e05c6136d80f71c0ad9198479e1a88e3437680993cda4
+      # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-6
+      image: ghcr.io/argotorg/solidity-buildpack-deps@sha256:c0412c53e59ce0c96bde4c08e7332ea12e4cadba9bbac829621947897fa21272
 
     steps:
       - name: Checkout code
@@ -119,9 +119,9 @@ jobs:
       CPUs: 5
 
     container:
-      # solbuildpackpusher/solidity-buildpack-deps:emscripten-20
+      # ghcr.io/argotorg/solidity-buildpack-deps:emscripten-21
       # NOTE: Keep in sync with the digest in scripts/build_emscripten.sh
-      image: solbuildpackpusher/solidity-buildpack-deps@sha256:98f963ed799a0d206ef8e7b5475f847e0dea53b7fdea9618bbc6106a62730bd2
+      image: ghcr.io/argotorg/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- align the GitHub Actions Linux build image with CircleCI's `ubuntu2404-6` image
- align the GitHub Actions Emscripten build image with CircleCI's `emscripten-21` image
- keep both images pinned to the same digests used by `.circleci/config.yml`

## Root cause

PR #133 raised the minimum Boost version to 1.83 and updated the CircleCI and Emscripten script images, but `.github/workflows/build.yml` still used the older images. The Emscripten job therefore ran with Boost 1.75 and failed during CMake configuration.

Failed build: https://github.com/tronprotocol/solidity/actions/runs/29410477729/job/87336095268

## Impact

The Emscripten build can use the required Boost 1.83 toolchain, and the GitHub Actions Linux/Emscripten environments no longer drift from CircleCI.

## Validation

- parsed `.github/workflows/build.yml` successfully as YAML
- ran `git diff --check`
- verified both pinned GHCR image manifests resolve successfully
- confirmed the image names and digests exactly match `.circleci/config.yml`

`actionlint` was not available locally.
