### PR TITLE
ci: streamline release builds on GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -14,6 +14,6 @@ mkdir -p build
 cd build
 
 # shellcheck disable=SC2086
-cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS -G "Unix Makefiles"
+cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" -DTESTS=OFF $CMAKE_OPTIONS -G "Unix Makefiles"
 
-make
+make solc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ on:
 
 jobs:
   b_windows:
-    runs-on: [ self-hosted, Windows ]
+    runs-on: windows-2022
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
-      - name: Fix git safe directory
-        run: git config --global --add safe.directory '*'
+        with:
+          submodules: true
 
       - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v5
         with:
-          path: .\deps
-          key: dependencies-win-${{ runner.arch }}-${{ hashFiles('scripts/install_deps.ps1') }}
-          restore-keys: dependencies-win-${{ runner.arch }}-
+          path: |
+            .\deps\boost
+            .\deps\cmake
+          key: hosted-dependencies-win-v2-${{ runner.arch }}-${{ hashFiles('scripts/install_deps.ps1') }}
 
       - name: Installing dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -39,26 +39,68 @@ jobs:
           mkdir github/
           cp build/solc/Release/solc.exe github/solc-windows.exe
 
-      - name: Save artifact to cache
-        uses: actions/cache/save@v5
+      - name: Upload Windows binary
+        uses: actions/upload-artifact@v4
         with:
+          name: solc-windows
           path: github/solc-windows.exe
-          key: solc-windows-${{ github.run_id }}
-          enableCrossOsArchive: true
+          if-no-files-found: error
 
   b_macos:
-    runs-on: [ self-hosted, macOS ]
+    runs-on: macos-15
 
     env:
       CMAKE_BUILD_TYPE: Release
-      CMAKE_OPTIONS: -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64
+      CMAKE_OPTIONS: -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64 -DBoost_ROOT=${{ github.workspace }}/deps/boost -DBoost_NO_SYSTEM_PATHS=ON
       TERM: xterm
-      MAKEFLAGS: -j5
-      CPUs: 5
+      MAKEFLAGS: -j 3
+      CPUs: 3
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Select pinned macOS toolchain
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
+          bash .circleci/install_cmake.sh 3.29.3
+          xcodebuild -version
+          clang --version
+          cmake --version
+
+      - name: Cache universal Boost
+        id: cache-boost
+        uses: actions/cache@v5
+        with:
+          path: deps/boost
+          key: hosted-boost-macos-universal-1.84.0-xcode16.4-v1
+
+      - name: Build universal Boost
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        run: |
+          boost_version=1.84.0
+          boost_dir="boost_${boost_version//./_}"
+          boost_archive="${RUNNER_TEMP}/${boost_dir}.tar.bz2"
+
+          curl --fail --location --retry 3 \
+            "https://archives.boost.io/release/${boost_version}/source/${boost_dir}.tar.bz2" \
+            --output "${boost_archive}"
+          tar -xjf "${boost_archive}" -C "${RUNNER_TEMP}"
+
+          cd "${RUNNER_TEMP}/${boost_dir}"
+          ./bootstrap.sh \
+            --with-toolset=clang \
+            --with-libraries=filesystem,program_options,system,test
+          ./b2 -j 3 -d0 \
+            link=static \
+            variant=release \
+            threading=multi \
+            address-model=64 \
+            architecture=arm+x86 \
+            --prefix="${GITHUB_WORKSPACE}/deps/boost" \
+            install
 
       - name: Run build script
         shell: bash -el {0}
@@ -69,21 +111,21 @@ jobs:
           mkdir github/
           cp build/solc/solc github/solc-macos
 
-      - name: Save artifact to cache
-        uses: actions/cache/save@v5
+      - name: Upload macOS binary
+        uses: actions/upload-artifact@v4
         with:
+          name: solc-macos
           path: github/solc-macos
-          key: solc-macos-${{ github.run_id }}
-          enableCrossOsArchive: true
+          if-no-files-found: error
 
   b_linux:
-    runs-on: [ self-hosted, Linux, for-linux ]
+    runs-on: ubuntu-24.04
 
     env:
       CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DSOLC_LINK_STATIC=ON
       TERM: xterm
-      MAKEFLAGS: -j 10
-      CPUs: 10
+      MAKEFLAGS: -j 4
+      CPUs: 4
 
     container:
       # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-6
@@ -92,6 +134,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: true
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
@@ -104,11 +148,12 @@ jobs:
           mkdir github/
           cp build/solc/solc github/solc-static-linux
 
-      - name: Save artifact to cache
-        uses: actions/cache/save@v5
+      - name: Upload Linux binary
+        uses: actions/upload-artifact@v4
         with:
+          name: solc-linux
           path: github/solc-static-linux
-          key: solc-linux-${{ github.run_id }}
+          if-no-files-found: error
 
   b_linux_arm:
     runs-on: ubuntu-24.04-arm
@@ -126,6 +171,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: true
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
@@ -138,19 +185,20 @@ jobs:
           mkdir github/
           cp build/solc/solc github/solc-static-linux-arm
 
-      - name: Save artifact to cache
-        uses: actions/cache/save@v5
+      - name: Upload Linux ARM64 binary
+        uses: actions/upload-artifact@v4
         with:
+          name: solc-linux-arm
           path: github/solc-static-linux-arm
-          key: solc-linux-arm-${{ github.run_id }}
+          if-no-files-found: error
 
   b_ems:
-    runs-on: [ self-hosted, Linux, for-ems ]
+    runs-on: ubuntu-24.04
 
     env:
       TERM: xterm
-      MAKEFLAGS: -j 10
-      CPUs: 5
+      MAKEFLAGS: -j 4
+      CPUs: 4
 
     container:
       # ghcr.io/argotorg/solidity-buildpack-deps:emscripten-21
@@ -160,6 +208,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: true
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory '*'
@@ -172,53 +222,55 @@ jobs:
           mkdir github/
           cp upload/soljson.js github/soljson.js
 
-      - name: Save artifact to cache
-        uses: actions/cache/save@v5
+      - name: Upload Emscripten binary
+        uses: actions/upload-artifact@v4
         with:
+          name: solc-ems
           path: github/soljson.js
-          key: solc-ems-${{ github.run_id }}
+          if-no-files-found: error
 
   upload-to-s3:
     needs: [ b_windows, b_macos, b_linux, b_linux_arm, b_ems ]
 
-    runs-on: [ self-hosted, macOS ]
+    runs-on: [ self-hosted, Linux ]
 
     permissions:
       actions: read
       contents: read
 
     steps:
-      - name: Restore solc-windows
-        uses: actions/cache/restore@v5
+      - name: Download solc-windows
+        uses: actions/download-artifact@v4
         with:
-          path: github/solc-windows.exe
-          key: solc-windows-${{ github.run_id }}
-          enableCrossOsArchive: true
+          name: solc-windows
+          path: github
 
-      - name: Restore solc-macos
-        uses: actions/cache/restore@v5
+      - name: Download solc-macos
+        uses: actions/download-artifact@v4
         with:
-          path: github/solc-macos
-          key: solc-macos-${{ github.run_id }}
-          enableCrossOsArchive: true
+          name: solc-macos
+          path: github
 
-      - name: Restore solc-linux
-        uses: actions/cache/restore@v5
+      - name: Download solc-linux
+        uses: actions/download-artifact@v4
         with:
-          path: github/solc-static-linux
-          key: solc-linux-${{ github.run_id }}
+          name: solc-linux
+          path: github
 
-      - name: Restore solc-linux-arm
-        uses: actions/cache/restore@v5
+      - name: Download solc-linux-arm
+        uses: actions/download-artifact@v4
         with:
-          path: github/solc-static-linux-arm
-          key: solc-linux-arm-${{ github.run_id }}
+          name: solc-linux-arm
+          path: github
 
-      - name: Restore solc-ems
-        uses: actions/cache/restore@v5
+      - name: Download solc-ems
+        uses: actions/download-artifact@v4
         with:
-          path: github/soljson.js
-          key: solc-ems-${{ github.run_id }}
+          name: solc-ems
+          path: github
+
+      - name: Restore executable permissions
+        run: chmod +x github/solc-static-linux github/solc-static-linux-arm github/solc-macos
 
       - name: List all artifacts
         run: |
@@ -232,7 +284,7 @@ jobs:
       - name: Rename binaries to solc-bin naming convention
         run: |
           full_version=$(
-            github/solc-macos --version |
+            github/solc-static-linux --version |
             sed -En 's/^Version: ([0-9.]+.*\+commit\.[0-9a-f]+(\.mod)?).*$/\1/p'
           )
 
@@ -248,7 +300,7 @@ jobs:
           tar --create --file ../solc-bin-binaries.tar *
 
       - name: Upload to S3
-        shell: zsh -el {0}
+        shell: bash
         env:
           S3_BUCKET_PROD: ${{ secrets.S3_BUCKET_PROD }}
           S3_BUCKET_TEST: ${{ secrets.S3_BUCKET_TEST }}

--- a/.github/workflows/build_win.ps1
+++ b/.github/workflows/build_win.ps1
@@ -8,9 +8,7 @@ Write-Host "Building release version."
 mkdir build
 cd build
 $boost_dir=(Resolve-Path $PSScriptRoot\..\..\deps\boost\lib\cmake\Boost-*)
-..\deps\cmake\bin\cmake -G "Visual Studio 17 2022" -DBoost_DIR="$boost_dir\" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_INSTALL_PREFIX="$PSScriptRoot\..\..\upload" -DUSE_Z3=OFF ..
+..\deps\cmake\bin\cmake -G "Visual Studio 17 2022" -DBoost_DIR="$boost_dir\" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DUSE_Z3=OFF -DTESTS=OFF ..
 if ( -not $? ) { throw "CMake configure failed." }
-msbuild solidity.sln /p:Configuration=Release /m:10 /v:minimal
-if ( -not $? ) { throw "Build failed." }
-..\deps\cmake\bin\cmake --build . -j 10 --target install --config Release
-if ( -not $? ) { throw "Install target failed." }
+..\deps\cmake\bin\cmake --build . -j 10 --target solc --config Release
+if ( -not $? ) { throw "solc build failed." }


### PR DESCRIPTION
## Summary

- disable test targets and build only the release compiler target on native platforms
- migrate Windows, macOS, Linux AMD64, Linux ARM64, and Emscripten builds to GitHub-hosted runners
- pin the Windows runner to `windows-2022`
- pin macOS to `macos-15`, Xcode 16.4, CMake 3.29.3, and a cached universal Boost 1.84 build
- run Linux AMD64 and Emscripten builds on `ubuntu-24.04` and Linux ARM64 on `ubuntu-24.04-arm`
- transfer build outputs with Actions artifacts and gather them on the self-hosted Linux runner
- keep only the S3 packaging/upload job on `[self-hosted, Linux]`

## Why

The release workflow only consumes `solc` and `soljson`, so compiling test executables and auxiliary targets wastes build time. The platform builds no longer need persistent self-hosted machines once their dependencies and toolchains are prepared explicitly.

The S3 job remains self-hosted to preserve the existing production credentials and bucket-access environment.

## Impact

- Windows builds `solc.exe` with `TESTS=OFF` on `windows-2022`.
- macOS builds the existing `x86_64 + arm64` universal `solc` on `macos-15`.
- Linux AMD64 and ARM64 build their static `solc` binaries on native GitHub runners.
- Emscripten continues to build only `soljson`.
- Artifact executable bits are restored before packaging on Linux.
- The packaging job extracts the version from the Linux AMD64 binary instead of trying to run the macOS binary on Linux.

## Validation

- `actionlint` passed for `.github/workflows/build.yml`
- YAML runner graph, submodule checkout, and artifact upload/download pairing checks passed
- `git diff --check` passed
- `bash -n` passed for the Unix and Emscripten build scripts
- prior hosted-runner migration run passed Windows, macOS universal, macOS Intel-slice execution, Linux static, Emscripten, and release-format packaging: https://github.com/yanghang8612/solidity/actions/runs/29404474021
- prior Windows `TESTS=OFF` + `solc`-only benchmark and binary smoke test passed: https://github.com/yanghang8612/solidity/actions/runs/29407834749

The fork did not expose the production S3 secrets during the migration rehearsal. The S3 upload path remains on the repository's self-hosted Linux runner and will be exercised by the production workflow after merge.
