### PR TITLE
ci: fix S3 artifact handoff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           cp build/solc/Release/solc.exe github/solc-windows.exe
 
       - name: Upload Windows binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: solc-windows
           path: github/solc-windows.exe
@@ -112,7 +112,7 @@ jobs:
           cp build/solc/solc github/solc-macos
 
       - name: Upload macOS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: solc-macos
           path: github/solc-macos
@@ -149,7 +149,7 @@ jobs:
           cp build/solc/solc github/solc-static-linux
 
       - name: Upload Linux binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: solc-linux
           path: github/solc-static-linux
@@ -186,7 +186,7 @@ jobs:
           cp build/solc/solc github/solc-static-linux-arm
 
       - name: Upload Linux ARM64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: solc-linux-arm
           path: github/solc-static-linux-arm
@@ -223,7 +223,7 @@ jobs:
           cp upload/soljson.js github/soljson.js
 
       - name: Upload Emscripten binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: solc-ems
           path: github/soljson.js
@@ -232,7 +232,7 @@ jobs:
   upload-to-s3:
     needs: [ b_windows, b_macos, b_linux, b_linux_arm, b_ems ]
 
-    runs-on: [ self-hosted, Linux ]
+    runs-on: [ self-hosted, Linux, for-linux ]
 
     permissions:
       actions: read
@@ -240,31 +240,31 @@ jobs:
 
     steps:
       - name: Download solc-windows
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: solc-windows
           path: github
 
       - name: Download solc-macos
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: solc-macos
           path: github
 
       - name: Download solc-linux
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: solc-linux
           path: github
 
       - name: Download solc-linux-arm
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: solc-linux-arm
           path: github
 
       - name: Download solc-ems
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: solc-ems
           path: github


### PR DESCRIPTION
## Summary

- route `upload-to-s3` specifically to the self-hosted `for-linux` runner
- upgrade `actions/upload-artifact` from v4 to the Node.js 24-based v6
- upgrade `actions/download-artifact` from v4 to the Node.js 24-based v7

## Root cause

The S3 job used only `[self-hosted, Linux]`, which also matched the Emscripten runner. Run 29890009976 was therefore assigned to runner `ems` instead of runner `linux`.

The first artifact download reached the Azure Blob redirect but failed to download and extract the artifact after five retries. The upload step was never reached, so this failure was unrelated to S3 credentials.

The same run also warned that `actions/upload-artifact@v4` and `actions/download-artifact@v4` target deprecated Node.js 20. The runner forced those actions onto Node.js 24, producing additional `punycode` and `Buffer()` deprecation warnings.

## Impact

- the S3 job can no longer be scheduled on the `ems` runner
- artifact actions run natively on Node.js 24 without the Node.js 20 compatibility warnings
- artifact names, paths, packaging, and S3 destinations are unchanged

## Validation

- `actionlint` passed with the repository's known custom `for-linux` runner label allowed
- YAML runner and action-version checks passed
- `git diff --check` passed
- the selected self-hosted Linux runner version observed in the previous run is 2.335.1, newer than the 2.327.1 minimum required by the Node.js 24 artifact actions

Failed production run: https://github.com/tronprotocol/solidity/actions/runs/29890009976
