### PR TITLE
ci: use production S3 bucket for binary uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,22 +302,16 @@ jobs:
       - name: Upload to S3
         shell: bash
         env:
-          S3_BUCKET_PROD: ${{ secrets.S3_BUCKET_PROD }}
-          S3_BUCKET_TEST: ${{ secrets.S3_BUCKET_TEST }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
         run: |
-          case "${GITHUB_REF_NAME}" in
-            develop)   bucket="${S3_BUCKET_PROD}" ;;
-            release_*) bucket="${S3_BUCKET_TEST}" ;;
-          esac
-          
-          aws s3 cp github-binaries.tar "s3://${bucket}/${{ github.sha }}/" --only-show-errors
-          aws s3 cp solc-bin-binaries.tar "s3://${bucket}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp github-binaries.tar "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp solc-bin-binaries.tar "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
           
           cd github
-          aws s3 cp solc-windows.exe "s3://${bucket}/${{ github.sha }}/" --only-show-errors
-          aws s3 cp solc-macos "s3://${bucket}/${{ github.sha }}/" --only-show-errors
-          aws s3 cp solc-static-linux "s3://${bucket}/${{ github.sha }}/" --only-show-errors
-          aws s3 cp solc-static-linux-arm "s3://${bucket}/${{ github.sha }}/" --only-show-errors
-          aws s3 cp soljson.js "s3://${bucket}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp solc-windows.exe "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp solc-macos "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp solc-static-linux "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp solc-static-linux-arm "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
+          aws s3 cp soljson.js "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
           
           cd .. && rm -rf github solc-bin *.tar


### PR DESCRIPTION
## Summary

- route all binary uploads to the production S3 bucket
- remove the release-branch selection of the test bucket
- keep the existing commit-SHA object prefix unchanged

## Why

The upload pipeline no longer distinguishes between production and test environments. Release branches should therefore use `S3_BUCKET_PROD` instead of `S3_BUCKET_TEST`. This also avoids the KMS authorization failure encountered when uploading to the test bucket.

## Impact

Both `develop` and `release_*` workflow runs upload release artifacts to the production bucket under `${{ github.sha }}/`.

## Validation

- parsed `.github/workflows/build.yml` as YAML
- ran `git diff --check`
- confirmed the commit changes only `.github/workflows/build.yml`
