### PR TITLE
ci: isolate S3 upload workspace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,49 +239,61 @@ jobs:
       contents: read
 
     steps:
+      - name: Prepare artifact workspace
+        id: artifact-workspace
+        shell: bash
+        run: |
+          artifact_work_dir="${RUNNER_TEMP}/solidity-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "${artifact_work_dir}/github"
+          echo "path=${artifact_work_dir}" >> "${GITHUB_OUTPUT}"
+
       - name: Download solc-windows
         uses: actions/download-artifact@v7
         with:
           name: solc-windows
-          path: github
+          path: ${{ steps.artifact-workspace.outputs.path }}/github
 
       - name: Download solc-macos
         uses: actions/download-artifact@v7
         with:
           name: solc-macos
-          path: github
+          path: ${{ steps.artifact-workspace.outputs.path }}/github
 
       - name: Download solc-linux
         uses: actions/download-artifact@v7
         with:
           name: solc-linux
-          path: github
+          path: ${{ steps.artifact-workspace.outputs.path }}/github
 
       - name: Download solc-linux-arm
         uses: actions/download-artifact@v7
         with:
           name: solc-linux-arm
-          path: github
+          path: ${{ steps.artifact-workspace.outputs.path }}/github
 
       - name: Download solc-ems
         uses: actions/download-artifact@v7
         with:
           name: solc-ems
-          path: github
+          path: ${{ steps.artifact-workspace.outputs.path }}/github
 
       - name: Restore executable permissions
+        working-directory: ${{ steps.artifact-workspace.outputs.path }}
         run: chmod +x github/solc-static-linux github/solc-static-linux-arm github/solc-macos
 
       - name: List all artifacts
+        working-directory: ${{ steps.artifact-workspace.outputs.path }}
         run: |
           ls -R github/
 
       - name: Create tarball for use on github
+        working-directory: ${{ steps.artifact-workspace.outputs.path }}
         run: |
           cd github
           tar --create --file ../github-binaries.tar *
 
       - name: Rename binaries to solc-bin naming convention
+        working-directory: ${{ steps.artifact-workspace.outputs.path }}
         run: |
           full_version=$(
             github/solc-static-linux --version |
@@ -301,6 +313,7 @@ jobs:
 
       - name: Upload to S3
         shell: bash
+        working-directory: ${{ steps.artifact-workspace.outputs.path }}
         env:
           S3_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
         run: |
@@ -313,5 +326,13 @@ jobs:
           aws s3 cp solc-static-linux "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
           aws s3 cp solc-static-linux-arm "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
           aws s3 cp soljson.js "s3://${S3_BUCKET}/${{ github.sha }}/" --only-show-errors
-          
-          cd .. && rm -rf github solc-bin *.tar
+
+      - name: Clean artifact workspace
+        if: always()
+        shell: bash
+        env:
+          ARTIFACT_WORK_DIR: ${{ steps.artifact-workspace.outputs.path }}
+        run: |
+          if [[ -n "${ARTIFACT_WORK_DIR}" ]]; then
+            rm -rf -- "${ARTIFACT_WORK_DIR}"
+          fi


### PR DESCRIPTION
## Summary

- download release artifacts into a run- and attempt-specific directory under `RUNNER_TEMP`
- run permission restoration, packaging, and S3 upload from that isolated directory
- clean the temporary workspace with an `always()` step

## Root cause

The self-hosted `for-linux` runner reuses its repository workspace. A root-owned `github/` directory was recreated there before the upload job started, so the `java-tron` runner user could not extract `solc-windows.exe`. This caused `actions/download-artifact` to retry five times and fail before the S3 upload step.

## Impact

The upload job no longer depends on the ownership or contents of the persistent repository workspace. Each workflow run attempt uses `${RUNNER_TEMP}/solidity-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` and removes it on success or failure.

This addresses the failure observed in https://github.com/tronprotocol/solidity/actions/runs/30004204683.

## Validation

- parsed `.github/workflows/build.yml` successfully as YAML
- ran `git diff --check`
- ran `actionlint` with the repository's custom `for-linux` runner label ignored
- confirmed the commit changes only `.github/workflows/build.yml`
