### PR TITLE
fix(evmasm): align gas estimates with TVM pricing

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -71,13 +71,13 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				m_state->storageContent().count(slot) &&
 				classes.knownNonZero(m_state->storageContent().at(slot))
 			))
-				gas = GasCosts::tvmSstoreResetGas; //@todo take refunds into account
+				gas = GasCosts::sstoreResetGasInTVM; //@todo take refunds into account
 			else
-				gas = GasCosts::tvmSstoreSetGas;
+				gas = GasCosts::sstoreSetGasInTVM;
 			break;
 		}
 		case Instruction::SLOAD:
-			gas = GasCosts::tvmSloadGas;
+			gas = GasCosts::sloadGasInTVM;
 			break;
 		case Instruction::RETURN:
 		case Instruction::REVERT:
@@ -122,13 +122,13 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		}
 		case Instruction::EXTCODESIZE:
-			gas = GasCosts::tvmExtCodeSizeGas;
+			gas = GasCosts::extCodeSizeGasInTVM;
 			break;
 		case Instruction::EXTCODEHASH:
-			gas = GasCosts::tvmExtCodeHashGas;
+			gas = GasCosts::extCodeHashGasInTVM;
 			break;
 		case Instruction::EXTCODECOPY:
-			gas = GasCosts::tvmExtCodeCopyGas;
+			gas = GasCosts::extCodeCopyGasInTVM;
 			gas += memoryGas(-1, -3);
 			gas += wordGas(GasCosts::copyGas, m_state->relativeStackElement(-3));
 			break;
@@ -157,7 +157,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				gas = GasConsumption::infinite();
 			else
 			{
-				gas = GasCosts::tvmCallGas;
+				gas = GasCosts::callGasInTVM;
 				if (u256 const* value = classes.knownConstant(m_state->relativeStackElement(0)))
 					gas += (*value);
 				else
@@ -180,7 +180,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		}
 		case Instruction::SELFDESTRUCT:
-			gas = GasCosts::tvmSelfdestructGas;
+			gas = GasCosts::selfdestructGasInTVM;
 			gas += GasCosts::callNewAccountGas; // We very rarely know whether the address exists.
 			break;
 		case Instruction::CREATE:
@@ -211,27 +211,27 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 		case Instruction::BALANCE:
 		case Instruction::TOKENBALANCE:
 		case Instruction::ISCONTRACT:
-			gas = GasCosts::tvmBalanceGas;
+			gas = GasCosts::balanceGasInTVM;
 			break;
 		case Instruction::NATIVEFREEZE:
-			gas = GasCosts::freezeV1Gas;
+			gas = GasCosts::freezeV1GasInTVM;
 			gas += GasCosts::callNewAccountGas;
 			break;
 		case Instruction::NATIVEUNFREEZE:
-			gas = GasCosts::freezeV1Gas;
+			gas = GasCosts::freezeV1GasInTVM;
 			break;
 		case Instruction::NATIVEFREEZEEXPIRETIME:
-			gas = GasCosts::expireTimeGas;
+			gas = GasCosts::freezeExpireTimeGasInTVM;
 			break;
 		case Instruction::NATIVEVOTE:
-			gas = GasCosts::voteGas;
+			gas = GasCosts::voteGasInTVM;
 			// NATIVEVOTE reads two Solidity memory arrays. The stack length values are element
 			// counts, not byte lengths, so include the array length slot and 32 bytes per element.
 			gas += memoryGasForWordArray(-3, -2);
 			gas += memoryGasForWordArray(-1, 0);
 			break;
 		case Instruction::NATIVEWITHDRAWREWARD:
-			gas = GasCosts::withdrawGas;
+			gas = GasCosts::withdrawRewardGasInTVM;
 			break;
 		case Instruction::NATIVEFREEZEBALANCEV2:
 		case Instruction::NATIVEUNFREEZEBALANCEV2:
@@ -239,7 +239,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 		case Instruction::NATIVEWITHDRAWEXPIREUNFREEZE:
 		case Instruction::NATIVEDELEGATERESOURCE:
 		case Instruction::NATIVEUNDELEGATERESOURCE:
-			gas = GasCosts::freezeV2Gas;
+			gas = GasCosts::freezeV2GasInTVM;
 			break;
 		case Instruction::CHAINID:
 			gas = runGas(Instruction::CHAINID, m_evmVersion);

--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -71,13 +71,13 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				m_state->storageContent().count(slot) &&
 				classes.knownNonZero(m_state->storageContent().at(slot))
 			))
-				gas = GasCosts::totalSstoreResetGas(m_evmVersion); //@todo take refunds into account
+				gas = GasCosts::tvmSstoreResetGas; //@todo take refunds into account
 			else
-				gas = GasCosts::totalSstoreSetGas(m_evmVersion);
+				gas = GasCosts::tvmSstoreSetGas;
 			break;
 		}
 		case Instruction::SLOAD:
-			gas = GasCosts::sloadGas(m_evmVersion);
+			gas = GasCosts::tvmSloadGas;
 			break;
 		case Instruction::RETURN:
 		case Instruction::REVERT:
@@ -122,13 +122,13 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		}
 		case Instruction::EXTCODESIZE:
-			gas = GasCosts::extCodeGas(m_evmVersion);
+			gas = GasCosts::tvmExtCodeSizeGas;
 			break;
 		case Instruction::EXTCODEHASH:
-			gas = GasCosts::balanceGas(m_evmVersion);
+			gas = GasCosts::tvmExtCodeHashGas;
 			break;
 		case Instruction::EXTCODECOPY:
-			gas = GasCosts::extCodeGas(m_evmVersion);
+			gas = GasCosts::tvmExtCodeCopyGas;
 			gas += memoryGas(-1, -3);
 			gas += wordGas(GasCosts::copyGas, m_state->relativeStackElement(-3));
 			break;
@@ -157,18 +157,20 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				gas = GasConsumption::infinite();
 			else
 			{
-				gas = GasCosts::callGas(m_evmVersion);
+				gas = GasCosts::tvmCallGas;
 				if (u256 const* value = classes.knownConstant(m_state->relativeStackElement(0)))
 					gas += (*value);
 				else
 					gas = GasConsumption::infinite();
-				if (_item.instruction() == Instruction::CALL || _item.instruction() == Instruction::CALLTOKEN)
-					gas += GasCosts::callNewAccountGas; // We very rarely know whether the address exists.
 				int valueSize = 1;
 				if (_item.instruction() == Instruction::DELEGATECALL || _item.instruction() == Instruction::STATICCALL)
 					valueSize = 0;
 				else if (!classes.knownZero(m_state->relativeStackElement(-1 - valueSize)))
+				{
 					gas += GasCosts::callValueTransferGas;
+					if (_item.instruction() == Instruction::CALL || _item.instruction() == Instruction::CALLTOKEN)
+						gas += GasCosts::callNewAccountGas; // We very rarely know whether the address exists.
+				}
 				int tokenIdSize = 0;
 				if (_item.instruction() == Instruction::CALLTOKEN)
 					tokenIdSize = 1;
@@ -178,7 +180,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 			break;
 		}
 		case Instruction::SELFDESTRUCT:
-			gas = GasCosts::selfdestructGas(m_evmVersion);
+			gas = GasCosts::tvmSelfdestructGas;
 			gas += GasCosts::callNewAccountGas; // We very rarely know whether the address exists.
 			break;
 		case Instruction::CREATE:
@@ -209,7 +211,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 		case Instruction::BALANCE:
 		case Instruction::TOKENBALANCE:
 		case Instruction::ISCONTRACT:
-			gas = GasCosts::balanceGas(m_evmVersion);
+			gas = GasCosts::tvmBalanceGas;
 			break;
 		case Instruction::NATIVEFREEZE:
 			gas = GasCosts::freezeV1Gas;

--- a/libevmasm/GasMeter.h
+++ b/libevmasm/GasMeter.h
@@ -181,21 +181,21 @@ namespace GasCosts
 
 	// TVM keeps fixed Energy prices for these instructions. Do not derive them
 	// from Ethereum hard-fork-dependent EVM prices when estimating TRON code.
-	static unsigned const tvmSloadGas = 50;
-	static unsigned const tvmSstoreSetGas = 20000;
-	static unsigned const tvmSstoreResetGas = 5000;
-	static unsigned const tvmBalanceGas = 20;
-	static unsigned const tvmExtCodeSizeGas = 20;
-	static unsigned const tvmExtCodeCopyGas = 20;
-	static unsigned const tvmExtCodeHashGas = 400;
-	static unsigned const tvmCallGas = 40;
-	static unsigned const tvmSelfdestructGas = 5000;
+	static unsigned const sloadGasInTVM = 50;
+	static unsigned const sstoreSetGasInTVM = 20000;
+	static unsigned const sstoreResetGasInTVM = 5000;
+	static unsigned const balanceGasInTVM = 20;
+	static unsigned const extCodeSizeGasInTVM = 20;
+	static unsigned const extCodeCopyGasInTVM = 20;
+	static unsigned const extCodeHashGasInTVM = 400;
+	static unsigned const callGasInTVM = 40;
+	static unsigned const selfdestructGasInTVM = 5000;
 
-	static unsigned const freezeV1Gas = 20000;
-	static unsigned const expireTimeGas = 50;
-	static unsigned const freezeV2Gas = 10000;
-	static unsigned const withdrawGas = 20000;
-	static unsigned const voteGas = 30000;
+	static unsigned const freezeV1GasInTVM = 20000;
+	static unsigned const freezeExpireTimeGasInTVM = 50;
+	static unsigned const freezeV2GasInTVM = 10000;
+	static unsigned const withdrawRewardGasInTVM = 20000;
+	static unsigned const voteGasInTVM = 30000;
 }
 
 /**

--- a/libevmasm/GasMeter.h
+++ b/libevmasm/GasMeter.h
@@ -179,6 +179,18 @@ namespace GasCosts
 	static unsigned const copyGas = 3;
 	static unsigned const rjumpiGas = 4;
 
+	// TVM keeps fixed Energy prices for these instructions. Do not derive them
+	// from Ethereum hard-fork-dependent EVM prices when estimating TRON code.
+	static unsigned const tvmSloadGas = 50;
+	static unsigned const tvmSstoreSetGas = 20000;
+	static unsigned const tvmSstoreResetGas = 5000;
+	static unsigned const tvmBalanceGas = 20;
+	static unsigned const tvmExtCodeSizeGas = 20;
+	static unsigned const tvmExtCodeCopyGas = 20;
+	static unsigned const tvmExtCodeHashGas = 400;
+	static unsigned const tvmCallGas = 40;
+	static unsigned const tvmSelfdestructGas = 5000;
+
 	static unsigned const freezeV1Gas = 20000;
 	static unsigned const expireTimeGas = 50;
 	static unsigned const freezeV2Gas = 10000;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -3256,7 +3256,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::callGasInTVM + 10;
 		if (_functionType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		if (!existenceChecked)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -3256,7 +3256,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::callGas(m_context.evmVersion()) + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
 		if (_functionType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		if (!existenceChecked)

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1760,7 +1760,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		{
 			// @todo The value 10 is not exact and this could be fine-tuned,
 			// but this has worked for years in the old code generator.
-			u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10 + evmasm::GasCosts::callNewAccountGas;
+			u256 gasNeededByCaller = evmasm::GasCosts::callGasInTVM + 10 + evmasm::GasCosts::callNewAccountGas;
 			templ("gas", "sub(gas(), " + formatNumber(gasNeededByCaller) + ")");
 		}
 
@@ -3189,7 +3189,7 @@ void IRGeneratorForStatements::appendExternalFunctionCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::callGasInTVM + 10;
 		if (funType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		if (!checkExtcodesize)
@@ -3298,7 +3298,7 @@ void IRGeneratorForStatements::appendBareCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::callGasInTVM + 10;
 		if (funType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		gasNeededByCaller += evmasm::GasCosts::callNewAccountGas; // we never know

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1760,7 +1760,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		{
 			// @todo The value 10 is not exact and this could be fine-tuned,
 			// but this has worked for years in the old code generator.
-			u256 gasNeededByCaller = evmasm::GasCosts::callGas(m_context.evmVersion()) + 10 + evmasm::GasCosts::callNewAccountGas;
+			u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10 + evmasm::GasCosts::callNewAccountGas;
 			templ("gas", "sub(gas(), " + formatNumber(gasNeededByCaller) + ")");
 		}
 
@@ -3189,7 +3189,7 @@ void IRGeneratorForStatements::appendExternalFunctionCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::callGas(m_context.evmVersion()) + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
 		if (funType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		if (!checkExtcodesize)
@@ -3298,7 +3298,7 @@ void IRGeneratorForStatements::appendBareCall(
 	{
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		u256 gasNeededByCaller = evmasm::GasCosts::callGas(m_context.evmVersion()) + 10;
+		u256 gasNeededByCaller = evmasm::GasCosts::tvmCallGas + 10;
 		if (funType.valueSet())
 			gasNeededByCaller += evmasm::GasCosts::callValueTransferGas;
 		gasNeededByCaller += evmasm::GasCosts::callNewAccountGas; // we never know

--- a/test/libevmasm/GasMeter.cpp
+++ b/test/libevmasm/GasMeter.cpp
@@ -30,6 +30,9 @@
 
 #include <memory>
 #include <optional>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 using namespace solidity::evmasm;
 using namespace solidity::langutil;
@@ -39,6 +42,26 @@ namespace solidity::frontend::test
 
 namespace
 {
+GasMeter::GasConsumption estimateInstruction(
+	Instruction _instruction,
+	AssemblyItems _arguments,
+	bool _includeExternalCosts = true,
+	EVMVersion _evmVersion = EVMVersion{}
+)
+{
+	_arguments.emplace_back(_instruction);
+	GasMeter meter(std::make_shared<KnownState>(), _evmVersion);
+	GasMeter::GasConsumption gas;
+	for (AssemblyItem const& item: _arguments)
+		gas = meter.estimateMax(item, _includeExternalCosts);
+	return gas;
+}
+
+AssemblyItems zeroArguments(size_t _count)
+{
+	return AssemblyItems(_count, AssemblyItem{u256(0)});
+}
+
 /// Feeds the four NATIVEVOTE arguments as constants (or CALLVALUE for an unknown
 /// element count) and returns the estimate for the NATIVEVOTE item itself.
 GasMeter::GasConsumption estimateVote(
@@ -67,6 +90,112 @@ GasMeter::GasConsumption estimateVote(
 }
 
 BOOST_AUTO_TEST_SUITE(EvmasmGasMeter)
+
+BOOST_AUTO_TEST_CASE(tvm_fixed_instruction_prices_do_not_depend_on_evm_version)
+{
+	std::vector<std::tuple<Instruction, size_t, unsigned>> const fixedCosts{
+		{Instruction::SLOAD, 1, GasCosts::tvmSloadGas},
+		{Instruction::BALANCE, 1, GasCosts::tvmBalanceGas},
+		{Instruction::TOKENBALANCE, 2, GasCosts::tvmBalanceGas},
+		{Instruction::ISCONTRACT, 1, GasCosts::tvmBalanceGas},
+		{Instruction::EXTCODESIZE, 1, GasCosts::tvmExtCodeSizeGas},
+		{Instruction::EXTCODECOPY, 4, GasCosts::tvmExtCodeCopyGas},
+		{Instruction::EXTCODEHASH, 1, GasCosts::tvmExtCodeHashGas},
+		{Instruction::NATIVEFREEZE, 3, GasCosts::freezeV1Gas + GasCosts::callNewAccountGas},
+		{Instruction::NATIVEUNFREEZE, 2, GasCosts::freezeV1Gas},
+		{Instruction::NATIVEFREEZEEXPIRETIME, 2, GasCosts::expireTimeGas},
+		{Instruction::NATIVEWITHDRAWREWARD, 0, GasCosts::withdrawGas},
+		{Instruction::NATIVEFREEZEBALANCEV2, 2, GasCosts::freezeV2Gas},
+		{Instruction::NATIVEUNFREEZEBALANCEV2, 2, GasCosts::freezeV2Gas},
+		{Instruction::NATIVECANCELALLUNFREEZEV2, 0, GasCosts::freezeV2Gas},
+		{Instruction::NATIVEWITHDRAWEXPIREUNFREEZE, 0, GasCosts::freezeV2Gas},
+		{Instruction::NATIVEDELEGATERESOURCE, 3, GasCosts::freezeV2Gas},
+		{Instruction::NATIVEUNDELEGATERESOURCE, 3, GasCosts::freezeV2Gas}
+	};
+
+	for (EVMVersion const& evmVersion: EVMVersion::allVersions())
+		for (auto const& [instruction, argumentCount, expected]: fixedCosts)
+		{
+			GasMeter::GasConsumption gas = estimateInstruction(
+				instruction,
+				zeroArguments(argumentCount),
+				true,
+				evmVersion
+			);
+			BOOST_REQUIRE(!gas.isInfinite);
+			BOOST_CHECK_EQUAL(gas.value, u256(expected));
+		}
+}
+
+BOOST_AUTO_TEST_CASE(tvm_sstore_uses_java_tron_set_and_reset_prices)
+{
+	GasMeter::GasConsumption set = estimateInstruction(Instruction::SSTORE, {u256(1), u256(0)});
+	BOOST_REQUIRE(!set.isInfinite);
+	BOOST_CHECK_EQUAL(set.value, u256(GasCosts::tvmSstoreSetGas));
+
+	GasMeter::GasConsumption reset = estimateInstruction(Instruction::SSTORE, {u256(0), u256(0)});
+	BOOST_REQUIRE(!reset.isInfinite);
+	BOOST_CHECK_EQUAL(reset.value, u256(GasCosts::tvmSstoreResetGas));
+}
+
+BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_prices)
+{
+	for (Instruction instruction: {Instruction::DELEGATECALL, Instruction::STATICCALL})
+	{
+		GasMeter::GasConsumption gas = estimateInstruction(instruction, zeroArguments(6), false);
+		BOOST_REQUIRE(!gas.isInfinite);
+		BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::tvmCallGas));
+	}
+
+	GasMeter::GasConsumption zeroValueCall = estimateInstruction(
+		Instruction::CALL,
+		{u256(0), u256(0), u256(0), u256(0), u256(0), u256(2), u256(0)},
+		false
+	);
+	BOOST_REQUIRE(!zeroValueCall.isInfinite);
+	BOOST_CHECK_EQUAL(zeroValueCall.value, u256(GasCosts::tvmCallGas));
+
+	GasMeter::GasConsumption valueCall = estimateInstruction(
+		Instruction::CALL,
+		{u256(0), u256(0), u256(0), u256(0), u256(1), u256(2), u256(0)},
+		false
+	);
+	BOOST_REQUIRE(!valueCall.isInfinite);
+	BOOST_CHECK_EQUAL(
+		valueCall.value,
+		u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
+	);
+
+	GasMeter::GasConsumption valueCallCode = estimateInstruction(
+		Instruction::CALLCODE,
+		{u256(0), u256(0), u256(0), u256(0), u256(1), u256(2), u256(0)},
+		false
+	);
+	BOOST_REQUIRE(!valueCallCode.isInfinite);
+	BOOST_CHECK_EQUAL(valueCallCode.value, u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas));
+}
+
+BOOST_AUTO_TEST_CASE(tvm_calltoken_uses_fixed_base_and_conditional_transfer_prices)
+{
+	GasMeter::GasConsumption zeroValue = estimateInstruction(
+		Instruction::CALLTOKEN,
+		{u256(0), u256(0), u256(0), u256(0), u256(1), u256(0), u256(2), u256(0)},
+		false
+	);
+	BOOST_REQUIRE(!zeroValue.isInfinite);
+	BOOST_CHECK_EQUAL(zeroValue.value, u256(GasCosts::tvmCallGas));
+
+	GasMeter::GasConsumption nonZeroValue = estimateInstruction(
+		Instruction::CALLTOKEN,
+		{u256(0), u256(0), u256(0), u256(0), u256(1), u256(1), u256(2), u256(0)},
+		false
+	);
+	BOOST_REQUIRE(!nonZeroValue.isInfinite);
+	BOOST_CHECK_EQUAL(
+		nonZeroValue.value,
+		u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
+	);
+}
 
 BOOST_AUTO_TEST_CASE(nativevote_charges_memory_expansion_for_word_arrays)
 {

--- a/test/libevmasm/GasMeter.cpp
+++ b/test/libevmasm/GasMeter.cpp
@@ -197,6 +197,16 @@ BOOST_AUTO_TEST_CASE(tvm_calltoken_uses_fixed_base_and_conditional_transfer_pric
 	);
 }
 
+BOOST_AUTO_TEST_CASE(tvm_selfdestruct_uses_fixed_price_plus_new_account_cost)
+{
+	// java-tron (EnergyCost.getSuicideCost3) charges SUICIDE_V2 plus
+	// NEW_ACCT_CALL when the inheritor is a dead account. The estimator
+	// conservatively always adds the new-account cost.
+	GasMeter::GasConsumption gas = estimateInstruction(Instruction::SELFDESTRUCT, zeroArguments(1));
+	BOOST_REQUIRE(!gas.isInfinite);
+	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::tvmSelfdestructGas + GasCosts::callNewAccountGas));
+}
+
 BOOST_AUTO_TEST_CASE(nativevote_charges_memory_expansion_for_word_arrays)
 {
 	// java-tron (EnergyCost.getVoteWitnessCost2/3) charges per array

--- a/test/libevmasm/GasMeter.cpp
+++ b/test/libevmasm/GasMeter.cpp
@@ -94,23 +94,23 @@ BOOST_AUTO_TEST_SUITE(EvmasmGasMeter)
 BOOST_AUTO_TEST_CASE(tvm_fixed_instruction_prices_do_not_depend_on_evm_version)
 {
 	std::vector<std::tuple<Instruction, size_t, unsigned>> const fixedCosts{
-		{Instruction::SLOAD, 1, GasCosts::tvmSloadGas},
-		{Instruction::BALANCE, 1, GasCosts::tvmBalanceGas},
-		{Instruction::TOKENBALANCE, 2, GasCosts::tvmBalanceGas},
-		{Instruction::ISCONTRACT, 1, GasCosts::tvmBalanceGas},
-		{Instruction::EXTCODESIZE, 1, GasCosts::tvmExtCodeSizeGas},
-		{Instruction::EXTCODECOPY, 4, GasCosts::tvmExtCodeCopyGas},
-		{Instruction::EXTCODEHASH, 1, GasCosts::tvmExtCodeHashGas},
-		{Instruction::NATIVEFREEZE, 3, GasCosts::freezeV1Gas + GasCosts::callNewAccountGas},
-		{Instruction::NATIVEUNFREEZE, 2, GasCosts::freezeV1Gas},
-		{Instruction::NATIVEFREEZEEXPIRETIME, 2, GasCosts::expireTimeGas},
-		{Instruction::NATIVEWITHDRAWREWARD, 0, GasCosts::withdrawGas},
-		{Instruction::NATIVEFREEZEBALANCEV2, 2, GasCosts::freezeV2Gas},
-		{Instruction::NATIVEUNFREEZEBALANCEV2, 2, GasCosts::freezeV2Gas},
-		{Instruction::NATIVECANCELALLUNFREEZEV2, 0, GasCosts::freezeV2Gas},
-		{Instruction::NATIVEWITHDRAWEXPIREUNFREEZE, 0, GasCosts::freezeV2Gas},
-		{Instruction::NATIVEDELEGATERESOURCE, 3, GasCosts::freezeV2Gas},
-		{Instruction::NATIVEUNDELEGATERESOURCE, 3, GasCosts::freezeV2Gas}
+		{Instruction::SLOAD, 1, GasCosts::sloadGasInTVM},
+		{Instruction::BALANCE, 1, GasCosts::balanceGasInTVM},
+		{Instruction::TOKENBALANCE, 2, GasCosts::balanceGasInTVM},
+		{Instruction::ISCONTRACT, 1, GasCosts::balanceGasInTVM},
+		{Instruction::EXTCODESIZE, 1, GasCosts::extCodeSizeGasInTVM},
+		{Instruction::EXTCODECOPY, 4, GasCosts::extCodeCopyGasInTVM},
+		{Instruction::EXTCODEHASH, 1, GasCosts::extCodeHashGasInTVM},
+		{Instruction::NATIVEFREEZE, 3, GasCosts::freezeV1GasInTVM + GasCosts::callNewAccountGas},
+		{Instruction::NATIVEUNFREEZE, 2, GasCosts::freezeV1GasInTVM},
+		{Instruction::NATIVEFREEZEEXPIRETIME, 2, GasCosts::freezeExpireTimeGasInTVM},
+		{Instruction::NATIVEWITHDRAWREWARD, 0, GasCosts::withdrawRewardGasInTVM},
+		{Instruction::NATIVEFREEZEBALANCEV2, 2, GasCosts::freezeV2GasInTVM},
+		{Instruction::NATIVEUNFREEZEBALANCEV2, 2, GasCosts::freezeV2GasInTVM},
+		{Instruction::NATIVECANCELALLUNFREEZEV2, 0, GasCosts::freezeV2GasInTVM},
+		{Instruction::NATIVEWITHDRAWEXPIREUNFREEZE, 0, GasCosts::freezeV2GasInTVM},
+		{Instruction::NATIVEDELEGATERESOURCE, 3, GasCosts::freezeV2GasInTVM},
+		{Instruction::NATIVEUNDELEGATERESOURCE, 3, GasCosts::freezeV2GasInTVM}
 	};
 
 	for (EVMVersion const& evmVersion: EVMVersion::allVersions())
@@ -131,11 +131,11 @@ BOOST_AUTO_TEST_CASE(tvm_sstore_uses_java_tron_set_and_reset_prices)
 {
 	GasMeter::GasConsumption set = estimateInstruction(Instruction::SSTORE, {u256(1), u256(0)});
 	BOOST_REQUIRE(!set.isInfinite);
-	BOOST_CHECK_EQUAL(set.value, u256(GasCosts::tvmSstoreSetGas));
+	BOOST_CHECK_EQUAL(set.value, u256(GasCosts::sstoreSetGasInTVM));
 
 	GasMeter::GasConsumption reset = estimateInstruction(Instruction::SSTORE, {u256(0), u256(0)});
 	BOOST_REQUIRE(!reset.isInfinite);
-	BOOST_CHECK_EQUAL(reset.value, u256(GasCosts::tvmSstoreResetGas));
+	BOOST_CHECK_EQUAL(reset.value, u256(GasCosts::sstoreResetGasInTVM));
 }
 
 BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_prices)
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_pr
 	{
 		GasMeter::GasConsumption gas = estimateInstruction(instruction, zeroArguments(6), false);
 		BOOST_REQUIRE(!gas.isInfinite);
-		BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::tvmCallGas));
+		BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::callGasInTVM));
 	}
 
 	GasMeter::GasConsumption zeroValueCall = estimateInstruction(
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_pr
 		false
 	);
 	BOOST_REQUIRE(!zeroValueCall.isInfinite);
-	BOOST_CHECK_EQUAL(zeroValueCall.value, u256(GasCosts::tvmCallGas));
+	BOOST_CHECK_EQUAL(zeroValueCall.value, u256(GasCosts::callGasInTVM));
 
 	GasMeter::GasConsumption valueCall = estimateInstruction(
 		Instruction::CALL,
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_pr
 	BOOST_REQUIRE(!valueCall.isInfinite);
 	BOOST_CHECK_EQUAL(
 		valueCall.value,
-		u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
+		u256(GasCosts::callGasInTVM + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
 	);
 
 	GasMeter::GasConsumption valueCallCode = estimateInstruction(
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(tvm_call_family_uses_fixed_base_and_conditional_transfer_pr
 		false
 	);
 	BOOST_REQUIRE(!valueCallCode.isInfinite);
-	BOOST_CHECK_EQUAL(valueCallCode.value, u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas));
+	BOOST_CHECK_EQUAL(valueCallCode.value, u256(GasCosts::callGasInTVM + GasCosts::callValueTransferGas));
 }
 
 BOOST_AUTO_TEST_CASE(tvm_calltoken_uses_fixed_base_and_conditional_transfer_prices)
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(tvm_calltoken_uses_fixed_base_and_conditional_transfer_pric
 		false
 	);
 	BOOST_REQUIRE(!zeroValue.isInfinite);
-	BOOST_CHECK_EQUAL(zeroValue.value, u256(GasCosts::tvmCallGas));
+	BOOST_CHECK_EQUAL(zeroValue.value, u256(GasCosts::callGasInTVM));
 
 	GasMeter::GasConsumption nonZeroValue = estimateInstruction(
 		Instruction::CALLTOKEN,
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(tvm_calltoken_uses_fixed_base_and_conditional_transfer_pric
 	BOOST_REQUIRE(!nonZeroValue.isInfinite);
 	BOOST_CHECK_EQUAL(
 		nonZeroValue.value,
-		u256(GasCosts::tvmCallGas + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
+		u256(GasCosts::callGasInTVM + GasCosts::callValueTransferGas + GasCosts::callNewAccountGas)
 	);
 }
 
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(tvm_selfdestruct_uses_fixed_price_plus_new_account_cost)
 	// conservatively always adds the new-account cost.
 	GasMeter::GasConsumption gas = estimateInstruction(Instruction::SELFDESTRUCT, zeroArguments(1));
 	BOOST_REQUIRE(!gas.isInfinite);
-	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::tvmSelfdestructGas + GasCosts::callNewAccountGas));
+	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::selfdestructGasInTVM + GasCosts::callNewAccountGas));
 }
 
 BOOST_AUTO_TEST_CASE(nativevote_charges_memory_expansion_for_word_arrays)
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(nativevote_charges_memory_expansion_for_word_arrays)
 	// i.e. 7 and 11 words: 3 * 11 = 33 on top of the flat vote cost.
 	GasMeter::GasConsumption gas = estimateVote(u256(128), u256(2), u256(256), u256(2));
 	BOOST_REQUIRE(!gas.isInfinite);
-	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::voteGas + 33));
+	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::voteGasInTVM + 33));
 }
 
 BOOST_AUTO_TEST_CASE(nativevote_charges_length_slot_for_empty_arrays)
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(nativevote_charges_length_slot_for_empty_arrays)
 	// ends are 128+32 and 512+32 bytes, i.e. 5 and 17 words: 3 * 17 = 51.
 	GasMeter::GasConsumption gas = estimateVote(u256(128), u256(0), u256(512), u256(0));
 	BOOST_REQUIRE(!gas.isInfinite);
-	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::voteGas + 51));
+	BOOST_CHECK_EQUAL(gas.value, u256(GasCosts::voteGasInTVM + 51));
 }
 
 BOOST_AUTO_TEST_CASE(nativevote_with_unknown_element_count_is_unbounded)


### PR DESCRIPTION
## Summary

- align `GasMeter` pricing with java-tron/TVM Energy costs instead of inheriting Ethereum fork pricing
- cover `SLOAD`, `SSTORE`, `BALANCE`, `EXTCODE*`, `CALL*`, `SELFDESTRUCT`, `TOKENBALANCE`, `ISCONTRACT`, and `CALLTOKEN`
- charge value transfer and new-account costs conditionally
- use the fixed TVM call price in pre-Tangerine `gasNeededByCaller` fallback paths
- name TVM-specific constants consistently as `operationGasInTVM`
- add focused unit coverage for the TVM cost table and conditional call costs

## Root cause

`GasMeter` reused Ethereum EVM-version-dependent costs such as EIP-1884, EIP-2200, and EIP-2929. TVM uses its own fixed Energy schedule for these opcodes, so compiler gas annotations and optimizer cost heuristics diverged substantially from java-tron execution costs. The pre-Tangerine call fallback paths also derived retained gas from the Ethereum-version-dependent call price.

This change affects compiler-side estimates and optimizer heuristics only. It does not change the Energy charged by java-tron at runtime.

## Validation

- `cmake --build build -j4 --target soltest`
- `build/test/soltest --run_test=EvmasmGasMeter -- --no-semantic-tests` — 8 test cases passed
- `git diff --check release_0.8.30...HEAD`
