### PR TITLE
fix: clarify TRON builtin parameter names

### DIFF
--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -366,8 +366,8 @@ void GlobalContext::addValidateMultiSignMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::boolean());
 	strings parameterNames;
-	parameterNames.push_back("address");
-	parameterNames.push_back("permissonid");
+	parameterNames.push_back("account");
+	parameterNames.push_back("permissionId");
 	parameterNames.push_back("content");
 	parameterNames.push_back("signatures");
 	strings returnParameterNames;
@@ -436,7 +436,7 @@ void GlobalContext::addIsSRCandidateMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::boolean());
 	strings parameterNames;
-	parameterNames.push_back("address");
+	parameterNames.push_back("srCandidate");
 	strings returnParameterNames;
 	returnParameterNames.push_back("ok");
 
@@ -460,8 +460,8 @@ void GlobalContext::addVoteCountMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::uint256());
 	strings parameterNames;
-	parameterNames.push_back("address");
-	parameterNames.push_back("address");
+	parameterNames.push_back("voter");
+	parameterNames.push_back("srCandidate");
 	strings returnParameterNames;
 	returnParameterNames.push_back("result");
 
@@ -484,7 +484,7 @@ void GlobalContext::addTotalVoteCountMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::uint256());
 	strings parameterNames;
-	parameterNames.push_back("address");
+	parameterNames.push_back("voter");
 	strings returnParameterNames;
 	returnParameterNames.push_back("result");
 
@@ -507,7 +507,7 @@ void GlobalContext::addReceivedVoteCountMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::uint256());
 	strings parameterNames;
-	parameterNames.push_back("address");
+	parameterNames.push_back("srCandidate");
 	strings returnParameterNames;
 	returnParameterNames.push_back("result");
 
@@ -530,7 +530,7 @@ void GlobalContext::addUsedVoteCountMethod() {
 	TypePointers returnParameterTypes;
 	returnParameterTypes.push_back(TypeProvider::uint256());
 	strings parameterNames;
-	parameterNames.push_back("address");
+	parameterNames.push_back("voter");
 	strings returnParameterNames;
 	returnParameterNames.push_back("result");
 

--- a/test/libsolidity/syntaxTests/tron/builtin_named_arguments.sol
+++ b/test/libsolidity/syntaxTests/tron/builtin_named_arguments.sol
@@ -1,0 +1,16 @@
+contract C {
+    function f(bytes[] memory signatures) public view {
+        validatemultisign({
+            account: address(this),
+            permissionId: 0,
+            content: bytes32(0),
+            signatures: signatures
+        });
+        isSrCandidate({srCandidate: address(this)});
+        voteCount({voter: address(this), srCandidate: address(this)});
+        totalVoteCount({voter: address(this)});
+        receivedVoteCount({srCandidate: address(this)});
+        usedVoteCount({voter: address(this)});
+    }
+}
+// ----


### PR DESCRIPTION
## Summary

- replace unusable, duplicate, or misspelled TRON builtin parameter names with semantic names
- make named-argument calls possible for `validatemultisign`, `voteCount`, and related vote-query builtins
- leave positional calls, ABI encoding, function selectors, event topics, and runtime behavior unchanged

## Root cause

Several global builtins registered address parameters as `address`. `validatemultisign` therefore could not be called with named arguments because `address` is a Solidity keyword, while `voteCount` registered both inputs under the same name. Its permission parameter was also exposed as the misspelled `permissonid`.

The corrected names are:

- `validatemultisign`: `account`, `permissionId`, `content`, `signatures`
- `isSrCandidate`: `srCandidate`
- `voteCount`: `voter`, `srCandidate`
- `totalVoteCount`: `voter`
- `receivedVoteCount`: `srCandidate`
- `usedVoteCount`: `voter`

## Compatibility

The removed `trcToken` ABI canonicalization is not part of this PR. Existing `trcToken` ABI names and selectors remain unchanged.

Position-based builtin calls are unchanged. The old named forms affected here were not usable: `address` cannot be parsed as a named-argument identifier, and the duplicate `address` keys for `voteCount` cannot be expressed.

## Validation

- `cmake --build build --target soltest -j2`
- `syntaxTests/tron/builtin_named_arguments` — passed
- `git diff --check origin/release_0.8.30...HEAD` — passed