### PR TITLE
docs: fix bug metadata for TRON 0.8.30 security backports + fix: reject Ethereum units in AST imports

### DIFF
--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -6,7 +6,7 @@
         "description": "When the compiler detects that a custom layout specifier puts contract's static storage area too close to the end of the address space, it emits a warning. To make the warning more useful, the compiler tries to point at the last storage variable in that area. For this reason it walks the linearized inheritance hierarchy in reverse (from the least to the most derived). The list is calculated once and stored in an AST annotation called ``linearizedBaseContracts``. The direct cause of the bug was the fact that the code that reverses the list was doing it in place rather than on a copy, modifying the annotation. This effectively reversed the order of base contracts seen by any component that runs after layout checks: later phases of analysis, AST export, code generator, SMTChecker, etc. The observable effect was a reversed order of state variable initialization, constructor invocation, virtual function/modifier resolution, leading either to miscompilations or internal compiler errors, depending on the specific usage. Since the source of the bug was in the analysis stage, it was independent of the codegen pipeline or optimizer settings. The main condition necessary to trigger the bug was the presence of the warning in the output. The other is presence of language constructs whose evaluation depends on the inheritance order. While potential effects are very serious, this requirement excludes the vast majority of contracts as intentionally placing the storage variables in the last 2**64 slots is highly discouraged, which was actually the main reason for adding this warning.",
         "link": "https://blog.soliditylang.org/2026/07/09/inheritance-order-reversal-on-storage-end-warning-bug/",
         "introduced": "0.8.29",
-        "fixed": "0.8.36",
+        "fixed": "0.8.30",
         "severity": "medium"
     },
     {
@@ -16,7 +16,7 @@
         "description": "To work around the 16-slot stack access limit of the EVM, the IR-based code generator can move local variables of stack-too-deep functions to fixed memory offsets. This relocation is unsound for recursive functions: a fixed offset would be shared by all activations of the function, so a recursive call would overwrite the caller's value. The stack limit evader therefore must not relocate variables of functions that are part of a recursive call chain. To this end, the call graph was searched for cycles using a path-based depth-first search that, once a function had been fully explored and popped from the search path, short-circuited on it on any later visit. As a result, a function shared between several intersecting cycles could be reached first through a path that did not yet close a cycle through it, get marked as finished, and then be skipped when a later path would have revealed that it does lie on a cycle. Such a function was misclassified as non-recursive. When a misclassified function was complex enough for the stack limit evader to relocate some of its variables, those variables were moved to fixed memory offsets and silently corrupted on recursion, producing wrong results rather than a compile-time error. Triggering the bug requires the IR pipeline, a set of mutually recursive functions whose call graph contains intersecting cycles, at least one of the functions in an undetected part of a cycle being complex enough to require relocation to memory, and an unfortunate processing order of the functions (which depends on the hashes of their Yul names). It is independent of whether the optimizer is enabled.",
         "link": "https://blog.soliditylang.org/2026/07/08/unsound-spill-in-mutual-recursion-bug/",
         "introduced": "0.7.2",
-        "fixed": "0.8.36",
+        "fixed": "0.8.30",
         "severity": "medium",
         "conditions": {
             "viaIR": true
@@ -29,7 +29,7 @@
         "description": "The IR-based code generator provides a set of Yul helper functions for basic operations, such as clearing, copying, encoding or type conversions. Not all functions are used by every contract. The codegen appends them to the generated sources individually, only when an operation that would invoke one of them is encountered. Utility functions are often specialized for different types and locations. Since Yul does not support generic functions, specialization is done by generating multiple versions of the same function, with the information distinguishing the variants embedded in their names. However, if not all the necessary bits of distinguishing information are properly accounted for, two helpers may end up with the same name, causing a collision. In this situation the codegen includes only one of them, with calls to both variants invoking it. This happened with the ``set_to_zero`` helper used when an area of transient or persistent storage needs to be cleared. The helper name was missing the location information, which resulted in a collision between the persistent and transient storage variants for the same type. This meant that contracts clearing both locations would actually clear only one, leaving the other untouched. Which location ended up being cleared depended on the order in which the code generator processed the input. The necessary condition to trigger the bug was the use of ``delete`` operator on a transient storage variable. This was due to value types being the only types supported in transient storage and ``delete`` being the only operation invoking the helper allowed on such types. The other necessary condition was clearing of persistent storage and in this case the range of affected operations was wider: operator ``delete``, array ``pop()`` or assignment that resulted in a longer array being overwritten with a shorter one. The cleared variable itself also did not necessarily have to be of the same type. It was enough that a matching value type was nested in it. It also did not always have to be the exact same value type - clearing operations on reference types are usually performed at slot granularity, treating every slot as ``uint256`` rather than clearing every value packed into it individually. To trigger the bug both operations had to be present within the same piece of bytecode. Independent contracts, not related through inheritance, would not affect each other this way. The presence of one operation only in creation code and the other only in deployed code would not trigger the bug either.",
         "link": "https://blog.soliditylang.org/2026/02/18/transient-storage-clearing-helper-collision-bug/",
         "introduced": "0.8.28",
-        "fixed": "0.8.34",
+        "fixed": "0.8.30",
         "severity": "high",
         "conditions": {
             "viaIR": true,
@@ -43,7 +43,7 @@
         "description": "Solidity makes it possible to define variables that extend past the last (2**256-th) slot of storage, which results in wrap-around back to slot zero. Since EVM uses 256-bit integer arithmetic, most operations on such variables just work. The only situation which requires special attention is iteration against absolute slot addresses: the invariant that the last slot belonging to a variable has the highest address does not hold. When implemented incorrectly, a loop over an array will immediately terminate if the container spans the end of storage - due to the initial position already being greater than the end position. This affected storage array clearing loops generated by both evmasm and IR pipelines. Additionally, (only in the evmasm pipeline) copying operations whose source was an array straddling the end of storage were also affected. At the language level, the buggy code would be generated for array assignment, array initialization, delete operator, <array>.pop() and <array>.push(). Note that a clearing loop is inserted by the compiler not only for invocations of the delete operator, but also to zero storage when overwriting a longer array with a shorter one, popping an element or even pushing an empty element to a dynamic array. Since clearing is a separate loop, it is possible for the bug to only affect it and not the copy operation it follows (which is always the case in the IR pipeline). The bug is extremely unlikely to be triggered accidentally due to the probabilistic impossibility of a short dynamic array being allocated right at the storage boundary. On the other hand, scenarios in which a user may place a static array there intentionally do not seem realistic and are limited to unusual layouts, in which a contract does not place any storage variables at slot zero (otherwise they would overlap the array).",
         "link": "https://blog.soliditylang.org/2025/12/18/lost-storage-array-write-on-slot-overflow-bug/",
         "introduced": "0.1.0",
-        "fixed": "0.8.32",
+        "fixed": "0.8.30",
         "severity": "low"
     },
     {
@@ -523,7 +523,7 @@
         "uid": "SOL-2017-5",
         "name": "ZeroFunctionSelector",
         "summary": "It is possible to craft the name of a function such that it is executed instead of the fallback function in very specific circumstances.",
-        "description": "If a function has a selector consisting only of zeros, is payable and part of a contract that does not have a fallback function and at most five external functions in total, this function is called instead of the fallback function if Ether is sent to the contract without data.",
+        "description": "If a function has a selector consisting only of zeros, is payable and part of a contract that does not have a fallback function and at most five external functions in total, this function is called instead of the fallback function if Trx is sent to the contract without data.",
         "fixed": "0.4.18",
         "severity": "very low"
     },
@@ -608,8 +608,8 @@
     {
         "uid": "SOL-2016-7",
         "name": "LibrariesNotCallableFromPayableFunctions",
-        "summary": "Library functions threw an exception when called from a call that received Ether.",
-        "description": "Library functions are protected against sending them Ether through a call. Since the DELEGATECALL opcode forwards the information about how much Ether was sent with a call, the library function incorrectly assumed that Ether was sent to the library and threw an exception.",
+        "summary": "Library functions threw an exception when called from a call that received Trx.",
+        "description": "Library functions are protected against sending them Trx through a call. Since the DELEGATECALL opcode forwards the information about how much Trx was sent with a call, the library function incorrectly assumed that Trx was sent to the library and threw an exception.",
         "severity": "low",
         "introduced": "0.4.0",
         "fixed": "0.4.2"
@@ -617,8 +617,8 @@
     {
         "uid": "SOL-2016-6",
         "name": "SendFailsForZeroEther",
-        "summary": "The send function did not provide enough gas to the recipient if no Ether was sent with it.",
-        "description": "The recipient of an Ether transfer automatically receives a certain amount of gas from the EVM to handle the transfer. In the case of a zero-transfer, this gas is not provided which causes the recipient to throw an exception.",
+        "summary": "The send function did not provide enough gas to the recipient if no Trx was sent with it.",
+        "description": "The recipient of an Trx transfer automatically receives a certain amount of gas from the EVM to handle the transfer. In the case of a zero-transfer, this gas is not provided which causes the recipient to throw an exception.",
         "severity": "low",
         "fixed": "0.4.0"
     },

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -2070,52 +2070,8 @@
         "released": "2021-03-23"
     },
     "0.8.30": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion",
-            "TransientStorageClearingHelperCollision",
-            "LostStorageArrayWriteOnSlotOverflow"
-        ],
+        "bugs": [],
         "released": "2025-05-07"
-    },
-    "0.8.31": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion",
-            "TransientStorageClearingHelperCollision",
-            "LostStorageArrayWriteOnSlotOverflow"
-        ],
-        "released": "2025-12-03"
-    },
-    "0.8.32": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion",
-            "TransientStorageClearingHelperCollision"
-        ],
-        "released": "2025-12-18"
-    },
-    "0.8.33": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion",
-            "TransientStorageClearingHelperCollision"
-        ],
-        "released": "2025-12-18"
-    },
-    "0.8.34": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion"
-        ],
-        "released": "2026-02-18"
-    },
-    "0.8.35": {
-        "bugs": [
-            "InheritanceOrderReversalOnStorageEndWarning",
-            "UnsoundSpillInMutualRecursion"
-        ],
-        "released": "2026-04-29"
     },
     "0.8.4": {
         "bugs": [

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -288,6 +288,17 @@ bool SyntaxChecker::visit(Literal const& _literal)
 	if (_literal.token() != Token::Number)
 		return true;
 
+	Token const subDenomination = static_cast<Token>(_literal.subDenomination());
+	if (TokenTraits::isEtherSubdenomination(subDenomination))
+	{
+		m_errorReporter.parserError(
+			9999_error,
+			_literal.location(),
+			"Ether unit denomination is not supported by the compiler"
+		);
+		return true;
+	}
+
 	ASTString const& value = _literal.value();
 	solAssert(!value.empty(), "");
 

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -1236,13 +1236,12 @@ Literal::SubDenomination ASTJsonImporter::subdenomination(Json const& _node)
 
 	std::string const subDenStr = subDen.get<std::string>();
 
-	if (subDenStr == "wei")
-		return Literal::SubDenomination::Wei;
-	else if (subDenStr == "gwei")
-		return Literal::SubDenomination::Gwei;
-	else if (subDenStr == "ether")
-		return Literal::SubDenomination::Ether;
-	else if (subDenStr == "sun")
+	astAssert(
+		subDenStr != "wei" && subDenStr != "gwei" && subDenStr != "ether",
+		"Ether unit denomination is not supported by the compiler"
+	);
+
+	if (subDenStr == "sun")
 		return Literal::SubDenomination::Sun;
 	else if (subDenStr == "trx")
 		return Literal::SubDenomination::Trx;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1081,16 +1081,15 @@ std::tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _li
 	}
 	switch (_literal.subDenomination())
 	{
-		case Literal::SubDenomination::None:
 		case Literal::SubDenomination::Wei:
+		case Literal::SubDenomination::Gwei:
+		case Literal::SubDenomination::Ether:
+			// These denominations are not part of the TRON language, even if a
+			// Literal is constructed without going through the parser or AST importer.
+			return std::make_tuple(false, rational(0));
+		case Literal::SubDenomination::None:
 		case Literal::SubDenomination::Sun:
 		case Literal::SubDenomination::Second:
-			break;
-		case Literal::SubDenomination::Gwei:
-			value *= bigint("1000000000");
-			break;
-		case Literal::SubDenomination::Ether:
-			value *= bigint("1000000000000000000");
 			break;
 		case Literal::SubDenomination::Trx:
 			value *= bigint("1000000");

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1385,6 +1385,16 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 				if (binariesRequested)
 					compilerStack.compile();
 			}
+			catch (InvalidAstError const& _exc)
+			{
+				errors.emplace_back(formatErrorWithException(
+					compilerStack,
+					_exc,
+					Error::Type::JSONError,
+					"general",
+					"Failed to import AST"
+				));
+			}
 			catch (util::Exception const& _exc)
 			{
 				solThrow(util::Exception, "Failed to import AST: "s + _exc.what());

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -74,6 +74,26 @@ BOOST_AUTO_TEST_CASE(ufixed_types)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(ethereum_subdenominations_are_invalid)
+{
+	int64_t id = 0;
+	for (Literal::SubDenomination subdenomination: {
+		Literal::SubDenomination::Wei,
+		Literal::SubDenomination::Gwei,
+		Literal::SubDenomination::Ether
+	})
+	{
+		Literal literal(
+			++id,
+			SourceLocation{},
+			Token::Number,
+			std::make_shared<std::string>("1"),
+			subdenomination
+		);
+		BOOST_CHECK(TypeProvider::forLiteral(literal) == nullptr);
+	}
+}
+
 BOOST_AUTO_TEST_CASE(storage_layout_simple)
 {
 	MemberList members(MemberList::MemberMap({

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -1816,6 +1816,56 @@ BOOST_AUTO_TEST_CASE(stopAfter_ast_output)
 	BOOST_CHECK(result["sources"]["a.sol"]["ast"].is_object());
 }
 
+BOOST_AUTO_TEST_CASE(solidity_ast_rejects_ethereum_subdenominations)
+{
+	frontend::StandardCompiler compiler;
+	Json sourceInput = createLanguageAndSourcesSection("Solidity", {{
+		"A.sol",
+		"contract C { function f() public pure returns (uint256) { return 1 trx; } }"
+	}});
+	sourceInput["settings"]["outputSelection"]["*"][""] = Json::array({"ast"});
+
+	Json sourceResult = compiler.compile(sourceInput);
+	BOOST_REQUIRE(containsAtMostWarnings(sourceResult));
+	BOOST_REQUIRE(sourceResult["sources"]["A.sol"]["ast"].is_object());
+
+	for (std::string const& subdenomination: {"wei"s, "gwei"s, "ether"s})
+	{
+		Json ast = sourceResult["sources"]["A.sol"]["ast"];
+		bool literalFound = false;
+		auto replaceSubdenomination = [&](auto&& _replaceSubdenomination, Json& _node) -> void {
+			if (_node.is_object())
+			{
+				if (_node.value("nodeType", "") == "Literal" && _node.value("subdenomination", "") == "trx")
+				{
+					_node["subdenomination"] = subdenomination;
+					literalFound = true;
+				}
+				for (Json& value: _node)
+					_replaceSubdenomination(_replaceSubdenomination, value);
+			}
+			else if (_node.is_array())
+				for (Json& value: _node)
+					_replaceSubdenomination(_replaceSubdenomination, value);
+		};
+		replaceSubdenomination(replaceSubdenomination, ast);
+		BOOST_REQUIRE(literalFound);
+
+		Json astInput = Json::object();
+		astInput["language"] = "SolidityAST";
+		astInput["sources"]["A.sol"]["ast"] = std::move(ast);
+		astInput["settings"]["outputSelection"]["*"]["*"] = Json::array({"evm.bytecode.object"});
+
+		Json astResult = compiler.compile(astInput);
+		BOOST_CHECK(containsError(
+			astResult,
+			"JSONError",
+			"Failed to import AST: Ether unit denomination is not supported by the compiler"
+		));
+		BOOST_CHECK(!astResult.contains("contracts"));
+	}
+}
+
 BOOST_AUTO_TEST_CASE(dependency_tracking_of_abstract_contract)
 {
 	char const* input = R"(


### PR DESCRIPTION
## Summary

This PR contains two commits addressing audit findings for the 0.8.30 release:

### Commit 1: `docs: fix bug metadata for TRON 0.8.30 security backports`

Follow-up fix for two documentation issues found in the 0.8.29 → 0.8.30 audit (PR #142 security backports):

1. **Bug version matrix inconsistency (docs/bugs.json, docs/bugs_by_version.json)**
   - SOL-2025-1 (`LostStorageArrayWriteOnSlotOverflow`), SOL-2026-1 (`TransientStorageClearingHelperCollision`), SOL-2026-2 (`UnsoundSpillInMutualRecursion`) and SOL-2026-3 (`InheritanceOrderReversalOnStorageEndWarning`) were backported to TRON 0.8.30 via #142, but their `fixed` fields still pointed at the upstream Ethereum releases (0.8.32/0.8.34/0.8.36). As a result, `bugs_by_version.json` claimed 0.8.30 is still affected by all four bugs.
   - The `fixed` fields now say `0.8.30` on this release line, and `docs/bugs_by_version.json` was regenerated with `scripts/update_bugs_by_version.py`: 0.8.29 correctly lists all four bugs as affecting it, while 0.8.30 lists none.
   - The regenerated file also drops the 0.8.31–0.8.36 entries, which is the deterministic output of the generator for this branch (its Changelog.md ends at 0.8.30); those entries were upstream merge leftovers inconsistent with this branch.

2. **TRON terminology regression (docs/bugs.json)**
   - The #142 cherry-picks overwrote TRON-adapted wording (`Trx`) with upstream wording (`Ether`) in three legacy bug entries: SOL-2017-5 (`ZeroFunctionSelector`), SOL-2016-7 (`LibrariesNotCallableFromPayableFunctions`), SOL-2016-6 (`SendFailsForZeroEther`).
   - Restored the exact 0.8.29-baseline wording.

### Commit 2: `fix: reject Ethereum units in AST imports`

Fixes a unit-policy inconsistency between compilation entry points (audit ref CR-009):

- **Problem**: the source parser explicitly rejects `wei`/`gwei`/`ether` (`Parser.cpp`, "Ether unit denomination is not supported by the compiler"), but the same literal node imported via Standard JSON `language=SolidityAST` was silently accepted and constant-evaluated with Ethereum multipliers (e.g. `1 ether` → `PUSH8 0x0de0b6b3a7640000`, 10^18 instead of TRX's 10^6).
- **Fix (three layers)**:
  1. `ASTJsonImporter::subdenomination()` now rejects `wei`/`gwei`/`ether` with `astAssert`; the new `catch (InvalidAstError)` in `StandardCompiler::compileSolidity()` turns it into a clean `JSONError` ("Failed to import AST: ...") instead of a fatal exception.
  2. `SyntaxChecker::visit(Literal)` rejects Ether denominations at the unified post-import analysis stage, with the same error id and message as the parser.
  3. `RationalNumberType::isValidLiteral()` treats `Wei`/`Gwei`/`Ether` as invalid, so even programmatically constructed Literals cannot be constant-evaluated with Ethereum multipliers.
- **Tests**: `StandardCompiler/solidity_ast_rejects_ethereum_subdenominations` (cross-entry end-to-end: compile `1 trx` from source, patch the exported AST to wei/gwei/ether, feed back via SolidityAST, expect JSONError and no contracts output) and `SolidityTypes/ethereum_subdenominations_are_invalid`.
- **Known residual (accepted)**: `libsolidity/experimental/analysis/TypeInference.cpp` still contains Ethereum multiplier handling for these denominations. It is unreachable — the experimental pipeline shares the same parser, and the AST import path is now guarded — and is intentionally left unchanged in this PR.

## Verification

- Docs commit: `python3 -m json.tool` passes for both files; `scripts/update_bugs_by_version.py` output is byte-identical (reproducible).
- Fix commit: both new tests pass; original PoC (ether/gwei via SolidityAST) now rejected with `JSONError` and no bytecode; source entry for `trx`/`sun`/time denominations unchanged (10^6 / 1 / time multipliers verified in bytecode); source entry still rejects `1 gwei` at parse time.
- Regression: `SolidityTypes`, `SyntaxChecker`, `ASTJSON` suites pass; `syntaxTests` failures (25) are byte-identical to the parent commit (all pre-existing fork debt); the 3 `StandardCompiler/basic_compilation` failures are the known pre-existing hardcoded-bytecode expectations not adapted to TRON token-value guards.

## Notes

- Draft: the version-matrix semantics (`fixed: 0.8.30` on the TRON release line vs upstream fixed versions) should be confirmed by reviewers before merge.